### PR TITLE
Fix package-all.cmd

### DIFF
--- a/package-all.cmd
+++ b/package-all.cmd
@@ -1,14 +1,13 @@
 @echo off
 SET _DOCKER_BUILD="true"
 docker -v > NUL
-if not errorlevel 0 (
+if errorlevel 1 (
     echo Linux RPM and DEB packaging requires a docker install
     SET _DOCKER_BUILD="false"
 )
 echo *** Sanity check Windows
-dotnet restore 
-dotnet test %*
-if not errorlevel 0 exit /b 1
+dotnet test --runtime win10-x64 %*
+if errorlevel 1 exit /b 1
 echo *** Building and packaging Windows Targets
 
 if %_DOCKER_BUILD% == "true" (
@@ -19,7 +18,7 @@ if %_DOCKER_BUILD% == "true" (
     msbuild /t:clean,restore,package /p:WindowsOnly=false;Configuration=Release %*
 )
 
-if not errorlevel 0 exit /b 1
+if errorlevel 1 exit /b 1
 if %_DOCKER_BUILD% == "true" (
   echo *** Building and packaging Unix/Linux Targets
   docker run --rm -v %cd%:/build mcr.microsoft.com/dotnet/core/sdk:3.0-buster /build/package.sh /p:TargetFramework=netcoreapp3.0 %*


### PR DESCRIPTION
1. Remove `dotnet restore`
   It's unnecessary as of .NET Core 2.0:
   https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-restore

2. Add `--runtime win10-x64` to `dotnet test` to fix this error:
   > NETSDK1031: It is not supported to build or publish a self-contained
   > application without specifying a RuntimeIdentifier.  Please either
   > specify a RuntimeIdentifier or set SelfContained to false.

3. Fix `if not errorlevel 0`
   `if not errorlevel 0` is true if ERRORLEVEL is negative, which was
   probably unintentional.  From https://ss64.com/nt/errorlevel.html:
   > IF ERRORLEVEL n statements should be read as IF Errorlevel >= number