### PR TITLE
add comment to simplify usage of corporate proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as publish
 
+# ENV http_proxy=http://proxy.corporation.example:8080
+# ENV https_proxy=http://proxy.corporation.example:8080
 COPY . /azure-relay-bridge/
 WORKDIR /azure-relay-bridge/src/azbridge
 RUN dotnet publish azbridge.csproj -c Release -f netcoreapp3.0 -p:SelfContained=false -p:PublishTrimmed=false -o /app


### PR DESCRIPTION
If one is behind a corporate proxy, the following lines uncommented and filled with the respective protocol, host name and port are needed to build the software using the builder image.