### PR TITLE
fix wrong uppercased endpoint flag in CONFIG.md and error string

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -51,7 +51,7 @@ address.
 
 Reserved. Not presently supported
 
-**-E endpoint_uri**
+**-e endpoint_uri**
 
 Azure Relay endpoint URI (see -x).
 
@@ -205,7 +205,7 @@ the verbosity.  The maximum is 3.
 
 Connection String. Azure Relay connection string for the namespace
 or for a specific Azure Relay. The Connection String properties
-can be overriden by the -E (Endpoint), -K (SharedAccessKeyName),
+can be overriden by the -e (Endpoint), -K (SharedAccessKeyName),
 -k (SharedAccessKey), -S (SharedAccessSignature) arguments.
 
 If an EntityPath is specified in the connection string, that name 

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
         [Option(CommandOptionType.SingleValue, ShortName = "s", Description = "Azure Relay shared access signature token")]
         public string Signature { get; set; }
 
-        [Option(CommandOptionType.SingleValue, ShortName = "x", Description = "Azure Relay connection string (overridden with -S -K -k -E)")]
+        [Option(CommandOptionType.SingleValue, ShortName = "x", Description = "Azure Relay connection string (overridden with -S -K -k -e)")]
         public string ConnectionString { get; internal set; }
 
         [Option(CommandOptionType.NoValue, ShortName = "v", Description = "Verbose log output")]


### PR DESCRIPTION
In CONFIG.md and the error string resulting from the connection string, the endpoint flag (-e) was incorrectly written as uppercase -E. Fixed it.