### PR TITLE
Bump Packaging.Targets to 0.1.189 to support Ubuntu 20.x

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,9 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <PackagingTargetsPackageVersion>0.1.129</PackagingTargetsPackageVersion>
+    <PackagingTargetsPackageVersion>0.1.189</PackagingTargetsPackageVersion>
     <WixPackageVersion>3.11.2</WixPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>2.1.1</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftDiagnosticsTracingEventSourcePackageVersion>1.1.28</MicrosoftDiagnosticsTracingEventSourcePackageVersion>

--- a/src/azbridge/azbridge.csproj
+++ b/src/azbridge/azbridge.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <DisableOutOfProcTaskHost>true</DisableOutOfProcTaskHost>
@@ -133,15 +133,6 @@
     <RpmDependency Include="krb5-libs" Version="" />
     <RpmDependency Include="libicu" Version="" />
     <RpmDependency Include="zlib" Version="" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('debian')) OR $(RuntimeIdentifier.StartsWith('ubuntu')) OR $(RuntimeIdentifier.StartsWith('linuxmint'))">
-    <!-- <DebDependency Include="lttng-ust" Version=""/> -->
-    <DebDependency Include="libcurl3 | libcurl4" Version=""/>
-    <DebDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1" Version="" />
-    <DebDependency Include="libkrb5-3" Version="" />
-    <DebDependency Include="zlib1g" Version="" />
-    <DebDependency Include="libicu52 | libicu55 | libicu57 | libicu60 | libicu62 | libicu63" Version="" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('opensuse'))">


### PR DESCRIPTION
I got this error when trying to install the generated .deb packages on Ubuntu 20.04:
> The following packages have unmet dependencies:
>  azbridge : Depends: libicu52 but it is not installable or
...
>                      libicu63 but it is not installable
>             Depends: libicu63 but it is not installable or
...
>                      libicu52 but it is not installable

Bumping Packaging.Targets to 0.1.189 brings this fix:
https://github.com/qmfrederik/dotnet-packaging/commit/04d565670e764e36c73b61be1ed9aacb13031031
which adds libicu66 (avaiable in Ubuntu 20.x) to the list of supported versions.

Note that libicu dependencies were actually duplicated, b/c they were specified in both azbridge.csproj and Packaging.Targets
* See https://github.com/qmfrederik/dotnet-packaging/blob/6ef34e121b683721f53506e530311c89b879a89d/Packaging.Targets/build/Packaging.Targets.targets