### PR TITLE
Add ConfigureAwait(false) to avoid deadlocks

### DIFF
--- a/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.xml
+++ b/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.xml
@@ -488,7 +488,7 @@
              await TaskEx.FromAsync(
                  (c, s) => ((Transaction)s).BeginCommit(c, s),
                  (a) => ((Transaction)a.AsyncState).EndCommit(a),
-                 transaction);
+                 transaction).ConfigureAwait(false);
             </param>
         </member>
         <member name="M:Microsoft.Azure.Relay.Bridge.TaskEx.FromAsync``1(System.Func{``0,System.AsyncCallback,System.Object,System.IAsyncResult},System.Action{System.IAsyncResult},``0,System.Object)">

--- a/src/Microsoft.Azure.Relay.Bridge/SocketRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/SocketRemoteForwarder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Relay.Bridge
             {
                 socket.SendBufferSize = socket.ReceiveBufferSize = 65536;
                 socket.SendTimeout = 60000;
-                await socket.ConnectAsync(new UnixDomainSocketEndPoint(targetServer));
+                await socket.ConnectAsync(new UnixDomainSocketEndPoint(targetServer)).ConfigureAwait(false);
                 var tcpstream = new NetworkStream(socket);
 
                 CancellationTokenSource socketAbort = new CancellationTokenSource();
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Relay.Bridge
                             .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted),
                         StreamPump.RunAsync(tcpstream, hybridConnectionStream, () => hybridConnectionStream.Shutdown(),
                             socketAbort.Token))
-                    .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted);
+                    .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted).ConfigureAwait(false);
             }
         }
     }

--- a/src/Microsoft.Azure.Relay.Bridge/StreamPump.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/StreamPump.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     int bytesRead;
 
                     bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
-                    
+
                     if (bytesRead == 0)
                     {
                         shutdownAction?.Invoke();

--- a/src/Microsoft.Azure.Relay.Bridge/TaskEx.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TaskEx.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Relay.Bridge
         ///  await TaskEx.FromAsync(
         ///      (c, s) => ((Transaction)s).BeginCommit(c, s),
         ///      (a) => ((Transaction)a.AsyncState).EndCommit(a),
-        ///      transaction);
+        ///      transaction).ConfigureAwait(false).ConfigureAwait(false);
         /// </param>
         public static Task FromAsync(Func<AsyncCallback, object, IAsyncResult> begin, Action<IAsyncResult> end, object state = null)
         {

--- a/src/Microsoft.Azure.Relay.Bridge/TcpLocalForwardBridge.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpLocalForwardBridge.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Relay.Bridge
 
                 try
                 {
-                    socket = await this.tcpListener.AcceptTcpClientAsync();
+                    socket = await this.tcpListener.AcceptTcpClientAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Relay.Bridge
                 var tcpstream = tcpClient.GetStream();
                 var socket = tcpClient.Client;
                 
-                using (var hybridConnectionStream = await HybridConnectionClient.CreateConnectionAsync())
+                using (var hybridConnectionStream = await HybridConnectionClient.CreateConnectionAsync().ConfigureAwait(false))
                 {
                     // read and write version preamble
                     hybridConnectionStream.WriteTimeout = 60000;
@@ -205,18 +205,18 @@ namespace Microsoft.Azure.Relay.Bridge
                         /*stream mode*/ 0,
                         (byte)portNameBytes.Length
                     };
-                    await hybridConnectionStream.WriteAsync(preamble, 0, preamble.Length);
-                    await hybridConnectionStream.WriteAsync(portNameBytes, 0, portNameBytes.Length);
-                    
+                    await hybridConnectionStream.WriteAsync(preamble, 0, preamble.Length).ConfigureAwait(false);
+                    await hybridConnectionStream.WriteAsync(portNameBytes, 0, portNameBytes.Length).ConfigureAwait(false);
+
                     byte[] replyPreamble = new byte[3];
                     for (int read = 0; read < replyPreamble.Length;)
                     {
                         var r = await hybridConnectionStream.ReadAsync(replyPreamble, read,
-                            replyPreamble.Length - read);
+                            replyPreamble.Length - read).ConfigureAwait(false);
                         if (r == 0)
                         {
-                            await hybridConnectionStream.ShutdownAsync(CancellationToken.None);
-                            await hybridConnectionStream.CloseAsync(CancellationToken.None);
+                            await hybridConnectionStream.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
+                            await hybridConnectionStream.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                             return;
                         }
                         read += r;
@@ -225,8 +225,8 @@ namespace Microsoft.Azure.Relay.Bridge
                     if (!(replyPreamble[0] == 1 && replyPreamble[1] == 0 && replyPreamble[2] == 0)) 
                     {
                         // version not supported
-                        await hybridConnectionStream.ShutdownAsync(CancellationToken.None);
-                        await hybridConnectionStream.CloseAsync(CancellationToken.None);
+                        await hybridConnectionStream.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
+                        await hybridConnectionStream.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                         return;
                     }
 
@@ -242,11 +242,11 @@ namespace Microsoft.Azure.Relay.Bridge
                                 .ContinueWith((t)=>socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted),
                             StreamPump.RunAsync(tcpstream, hybridConnectionStream,
                                 () => hybridConnectionStream?.Shutdown(), socketAbort.Token))
-                                .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted);
+                                .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted).ConfigureAwait(false);
 
                         using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1)))
                         {
-                            await hybridConnectionStream.CloseAsync(cts.Token);
+                            await hybridConnectionStream.CloseAsync(cts.Token).ConfigureAwait(false);
                         }
                     }
                     catch

--- a/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Relay.Bridge
                         () => client.Client.Shutdown(SocketShutdown.Send), socketAbort.Token)
                         .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted),
                     StreamPump.RunAsync(tcpstream, hybridConnectionStream, () => hybridConnectionStream.Shutdown(), socketAbort.Token))
-                        .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted);
+                        .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted).ConfigureAwait(false);
 
             }
 

--- a/src/Microsoft.Azure.Relay.Bridge/UdpLocalForwardBridge.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/UdpLocalForwardBridge.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Relay.Bridge
 
                 try
                 {
-                    datagram = await this.udpClient.ReceiveAsync();
+                    datagram = await this.udpClient.ReceiveAsync().ConfigureAwait(false);
                 }
                 catch (ObjectDisposedException)
                 {
@@ -153,12 +153,12 @@ namespace Microsoft.Azure.Relay.Bridge
                 {
                     using (var ct = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                     {
-                        await route.SendAsync(datagram, ct.Token);
+                        await route.SendAsync(datagram, ct.Token).ConfigureAwait(false);
                     }
                 }
                 else
                 {
-                    var hybridConnectionStream = await HybridConnectionClient.CreateConnectionAsync();
+                    var hybridConnectionStream = await HybridConnectionClient.CreateConnectionAsync().ConfigureAwait(false);
                     // read and write version preamble
                     hybridConnectionStream.WriteTimeout = 60000;
 
@@ -171,18 +171,18 @@ namespace Microsoft.Azure.Relay.Bridge
                         /*dgram*/ 1,
                         (byte)portNameBytes.Length
                     };
-                    await hybridConnectionStream.WriteAsync(preamble, 0, preamble.Length);
-                    await hybridConnectionStream.WriteAsync(portNameBytes, 0, portNameBytes.Length);
+                    await hybridConnectionStream.WriteAsync(preamble, 0, preamble.Length).ConfigureAwait(false);
+                    await hybridConnectionStream.WriteAsync(portNameBytes, 0, portNameBytes.Length).ConfigureAwait(false);
 
                     byte[] replyPreamble = new byte[3];
                     for (int read = 0; read < replyPreamble.Length;)
                     {
                         var r = await hybridConnectionStream.ReadAsync(replyPreamble, read,
-                            replyPreamble.Length - read);
+                            replyPreamble.Length - read).ConfigureAwait(false);
                         if (r == 0)
                         {
-                            await hybridConnectionStream.ShutdownAsync(CancellationToken.None);
-                            await hybridConnectionStream.CloseAsync(CancellationToken.None);
+                            await hybridConnectionStream.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
+                            await hybridConnectionStream.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                             return;
                         }
                         read += r;
@@ -191,8 +191,8 @@ namespace Microsoft.Azure.Relay.Bridge
                     if (!(replyPreamble[0] == 1 && replyPreamble[1] == 0 && replyPreamble[2] == 1))
                     {
                         // version not supported
-                        await hybridConnectionStream.ShutdownAsync(CancellationToken.None);
-                        await hybridConnectionStream.CloseAsync(CancellationToken.None);
+                        await hybridConnectionStream.ShutdownAsync(CancellationToken.None).ConfigureAwait(false);
+                        await hybridConnectionStream.CloseAsync(CancellationToken.None).ConfigureAwait(false);
                         return;
                     }
 
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     newRoute.StartReceiving();
                     using (var ct = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                     {
-                        await newRoute.SendAsync(datagram, ct.Token);
+                        await newRoute.SendAsync(datagram, ct.Token).ConfigureAwait(false);
                     }
                 }
             }
@@ -247,8 +247,8 @@ namespace Microsoft.Azure.Relay.Bridge
                 ms.Write(datagram.Buffer, 0, datagram.Buffer.Length);
                 if (!ct.IsCancellationRequested)
                 {
-                    await target.WriteAsync(buffer, 0, (int)ms.Length, ct);
-                    await target.FlushAsync(ct);
+                    await target.WriteAsync(buffer, 0, (int)ms.Length, ct).ConfigureAwait(false);
+                    await target.FlushAsync(ct).ConfigureAwait(false);
                 }
             }
         }
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     int read = 0;
                     while (read < 2)
                     {
-                        var r = await target.ReadAsync(length, 0, 2, this.routeCancel.Token);
+                        var r = await target.ReadAsync(length, 0, 2, this.routeCancel.Token).ConfigureAwait(false);
                         if (r == 0)
                         {
                             return;
@@ -280,14 +280,14 @@ namespace Microsoft.Azure.Relay.Bridge
                     int toRead = length[0] * 256 + length[1];
                     while (read < toRead)
                     {
-                        var r = await target.ReadAsync(buffer, 0, toRead, this.routeCancel.Token);
+                        var r = await target.ReadAsync(buffer, 0, toRead, this.routeCancel.Token).ConfigureAwait(false);
                         if (r == 0)
                         {
                             return;
                         }         
                         read += r;
                     }                                                                               
-                    await client.SendAsync(buffer, toRead, this.IPEndPoint);
+                    await client.SendAsync(buffer, toRead, this.IPEndPoint).ConfigureAwait(false);
                 }
                 while (!this.routeCancel.IsCancellationRequested);
             });

--- a/src/Microsoft.Azure.Relay.Bridge/UdpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/UdpRemoteForwarder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     Send(hybridConnectionStream, client, socketAbort)
                         .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted),
                     Receive(hybridConnectionStream, client, socketAbort)
-                        .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted));
+                        .ContinueWith((t) => socketAbort.Cancel(), TaskContinuationOptions.OnlyOnFaulted)).ConfigureAwait(false);
             }
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     int read = 0;
                     while (read < 2)
                     {
-                        var r = await source.ReadAsync(length, 0, 2, cancellationToken.Token);
+                        var r = await source.ReadAsync(length, 0, 2, cancellationToken.Token).ConfigureAwait(false);
                         if (r == 0)
                         {
                             return;
@@ -103,14 +103,14 @@ namespace Microsoft.Azure.Relay.Bridge
                     int toRead = length[0] * 256 + length[1];
                     while (read < toRead)
                     {
-                        var r = await source.ReadAsync(buffer, 0, toRead, cancellationToken.Token);
+                        var r = await source.ReadAsync(buffer, 0, toRead, cancellationToken.Token).ConfigureAwait(false);
                         if (r == 0)
                         {
                             return;
                         }
                         read += r;
                     }
-                    await target.SendAsync(buffer, toRead);
+                    await target.SendAsync(buffer, toRead).ConfigureAwait(false);
                 }
                 while (!cancellationToken.IsCancellationRequested);
             }
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Relay.Bridge
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    var datagram = await target.ReceiveAsync();
+                    var datagram = await target.ReceiveAsync().ConfigureAwait(false);
                     cancellationToken.CancelAfter(maxIdleTime);
                     var buffer = new byte[datagram.Buffer.Length + 2];
                     using (var ms = new MemoryStream(buffer))
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Relay.Bridge
                         ms.Write(datagram.Buffer, 0, datagram.Buffer.Length);
                         if (!cancellationToken.IsCancellationRequested)
                         {
-                            await source.WriteAsync(buffer, 0, (int)ms.Length, cancellationToken.Token);
+                            await source.WriteAsync(buffer, 0, (int)ms.Length, cancellationToken.Token).ConfigureAwait(false);
                         }
                     }
                 }


### PR DESCRIPTION
#31 Library should use ConfigureAwait(false) on all await method calls to avoid deadlocks