### PR TITLE
Build MSI installer for Windows platform

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -11,7 +11,52 @@ on:
     branches: [ master, main ]
 
 jobs:
-  build:
+  build-windows:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build for Windows 10-x64
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    - name: Build for Windows 10-x64 (Installer)
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=net48
+    - name: Build for Windows 10-arm64
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-arm /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    - name: Build for Windows 10-x86
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x86 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    
+    - name: Test
+      run: dotnet test /p:TargetFramework=netcoreapp5.0 /p:RuntimeIdentifier=ubuntu-x64 /p:Configuration=Debug
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: XBuild
+        path: |
+          artifacts/build/netcoreapp5.0
+          artifacts/build/net48
+    
+    - name: Upload Binaries to the Release
+      uses: svenstaro/upload-release-action@v2
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: artifacts/build/*/*
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true
+
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -25,20 +70,14 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Build for Windows 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
-    - name: Build for Windows 10-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-arm /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
-    - name: Build for Windows 10-x86
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x86 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
     - name: Build for macOS-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Ubuntu 18-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Ubuntu 18-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-arm64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-arm64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Debian 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=debian.10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=debian.10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     
     - name: Test
       run: dotnet test /p:TargetFramework=netcoreapp5.0 /p:RuntimeIdentifier=ubuntu-x64 /p:Configuration=Debug
@@ -46,7 +85,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: XBuild
-        path: artifacts/build/netcoreapp5.0
+        path: |
+          artifacts/build/netcoreapp5.0
     
     - name: Upload Binaries to the Release
       uses: svenstaro/upload-release-action@v2
@@ -55,7 +95,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: artifacts/build/netcoreapp5.0/*
+        file: artifacts/build/*/*
         file_glob: true
         tag: ${{ github.ref }}
         overwrite: true

--- a/InstallAzureRelay-Linux.sh
+++ b/InstallAzureRelay-Linux.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+set -eu
+
+drop_path="$1"
+connection_string="$2"
+relay_name="$3"
+bind_address="$4"
+port="$5"
+
+# Install package
+apt-get install $drop_path
+
+# Modify config file
+config_path=/etc/azbridge/azbridge_config.svc.yml
+install -D -m 644 /dev/null "config_path"
+cat <<EOF > $config_path
+LocalForward:
+- RelayName: $relay_name
+  ConnectionString: $connection_string
+  BindAddress: $bind_address
+  BindPort: $port
+EOF
+
+# Create and start azbridge systemd service
+service_name=azbridge.service
+service_path=/etc/systemd/system/$service_name
+install -D -m 644 /dev/null "$service_path"
+cat <<EOF > "$service_path"
+[Unit]
+Description=Azure Relay Bridge
+Before=vsts-provisioner.service
+After=network.target
+
+[Service]
+ExecStart=/usr/share/azbridge/azbridge -f /etc/azbridge/azbridge_config.svc.yml
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable "$service_name"
+systemctl start "$service_name"

--- a/InstallAzureRelay-Windows.ps1
+++ b/InstallAzureRelay-Windows.ps1
@@ -1,0 +1,44 @@
+#Requires -Version 5.1 # Shipped w/ Windows 10 1607 and Windows Server 2016
+param(
+    [Parameter(Mandatory=$true)][String]$DropPath,
+    [Parameter(Mandatory=$true)][String]$ConnectionString,
+    [Parameter(Mandatory=$true)][String]$RelayName,
+    [Parameter(Mandatory=$true)][String]$BindAddress,
+    [Parameter(Mandatory=$true)][Int]$Port)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$WarningPreference = 'Continue'
+
+# Install service non-interactively.
+# Start-Process -Wait prevents msiexec from returning before it finishes.
+# See https://powershellexplained.com/2016-10-21-powershell-installing-msi-files/
+$logPath = $DropPath + '.log'
+Start-Process msiexec -ArgumentList @('/i', $DropPath, '/qn', '/log' , $logPath) -Wait
+
+# Set config file
+$configDir = Join-Path $env:ALLUSERSPROFILE 'Microsoft\Azure Relay Bridge'
+$null = mkdir $configDir
+$configFile = Join-Path $configDir 'azbridge_config.svc.yml'
+@"
+LocalForward:
+- RelayName: $RelayName
+  ConnectionString: $ConnectionString
+  BindAddress: $BindAddress
+  BindPort: $Port
+"@ |
+    Set-Content `
+    -LiteralPath $configFile `
+    -Encoding UTF8
+
+if ($Port -eq 80) {
+  # IIS and W3SVC services might block using 80 port so we have to disable them
+  # Use "SilentlyContinue" because the list of services can be different on different versions of Windows Server
+  @('IISAdmin', 'W3SVC') | ForEach-Object { Stop-Service -Name $_ -ErrorAction SilentlyContinue }
+}
+
+# The installer already started the service, but StartupType is Manual.
+# Restart it to reload config, and fix StartupType.
+# See https://github.com/Azure/azure-relay-bridge/issues/11
+Stop-Service -Name azbridgesvc
+Set-Service -Name azbridgesvc -StartupType Automatic -Status Running


### PR DESCRIPTION
This PR adds a step in the CI to build the MSI installer artifact.

https://github.com/Azure/azure-relay-bridge/blob/10645d4994cf27cd6d2adce5793b520089b526b4/src/azbridge/azbridge.csproj#L195

In order to build the installer, Visual Studio 2019 Enterprise is required, hence using [`windows-2019`](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019) as the GitHub Actions runner.

https://github.com/Azure/azure-relay-bridge/blob/10645d4994cf27cd6d2adce5793b520089b526b4/src/azbridge/azbridge.csproj#L199