### PR TITLE
Build MSI installer for Windows platform

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -11,7 +11,52 @@ on:
     branches: [ master, main ]
 
 jobs:
-  build:
+  build-windows:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build for Windows 10-x64
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    - name: Build for Windows 10-x64 (Installer)
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=net48
+    - name: Build for Windows 10-arm64
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-arm /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    - name: Build for Windows 10-x86
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x86 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
+    
+    - name: Test
+      run: dotnet test /p:TargetFramework=netcoreapp5.0 /p:RuntimeIdentifier=ubuntu-x64 /p:Configuration=Debug
+    
+    - uses: actions/upload-artifact@v2
+      with:
+        name: XBuild
+        path: |
+          artifacts/build/netcoreapp5.0
+          artifacts/build/net48
+    
+    - name: Upload Binaries to the Release
+      uses: svenstaro/upload-release-action@v2
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: artifacts/build/*/*
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true
+
+  build-linux:
 
     runs-on: ubuntu-latest
 
@@ -25,20 +70,14 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Build for Windows 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
-    - name: Build for Windows 10-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-arm /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
-    - name: Build for Windows 10-x86
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x86 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
     - name: Build for macOS-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Ubuntu 18-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Ubuntu 18-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-arm64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-arm64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     - name: Build for Debian 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=debian.10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=debian.10-x64 /p:Configuration=Release /p:TargetFramework=netcoreapp5.0
     
     - name: Test
       run: dotnet test /p:TargetFramework=netcoreapp5.0 /p:RuntimeIdentifier=ubuntu-x64 /p:Configuration=Debug
@@ -46,7 +85,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: XBuild
-        path: artifacts/build/netcoreapp5.0
+        path: |
+          artifacts/build/netcoreapp5.0
     
     - name: Upload Binaries to the Release
       uses: svenstaro/upload-release-action@v2
@@ -55,7 +95,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: artifacts/build/netcoreapp5.0/*
+        file: artifacts/build/*/*
         file_glob: true
         tag: ${{ github.ref }}
         overwrite: true

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <PackagingTargetsPackageVersion>0.1.189</PackagingTargetsPackageVersion>
+    <PackagingTargetsPackageVersion>0.1.220</PackagingTargetsPackageVersion>
     <WixPackageVersion>3.11.2</WixPackageVersion>
     <MicrosoftDiagnosticsTracingEventSourcePackageVersion>1.1.28</MicrosoftDiagnosticsTracingEventSourcePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.66</MicrosoftDiagnosticsTracingTraceEventPackageVersion>

--- a/src/azbridge/azbridge.csproj
+++ b/src/azbridge/azbridge.csproj
@@ -141,7 +141,7 @@
     <DebDependency Include="libssl1.0.0 | libssl1.0.2 | libssl1.1" Version="" />
     <DebDependency Include="libgssapi-krb5-2"/>
     <DebDependency Include="zlib1g" Version="" />
-    <DebDependency Include="libicu52 | libicu55 | libicu57 | libicu60 | libicu62 | libicu63 | libicu66 | libicu67" Version="" />
+    <DebDependency Include="libicu52 | libicu55 | libicu57 | libicu60 | libicu62 | libicu63 | libicu66 | libicu67 | libicu68 | libicu69 | libicu70" Version="" />
   </ItemGroup>
 
   <ItemGroup Condition="$(RuntimeIdentifier.StartsWith('opensuse'))">

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
     <VersionSuffix>rtm</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Sequel to https://github.com/Azure/azure-relay-bridge/pull/34 as master@fork was updated.

This PR adds a step in the CI to build the MSI installer artifact.

https://github.com/Azure/azure-relay-bridge/blob/10645d4994cf27cd6d2adce5793b520089b526b4/src/azbridge/azbridge.csproj#L195

In order to build the installer, Visual Studio 2019 Enterprise is required, hence using [`windows-2019`](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019) as the GitHub Actions runner.

https://github.com/Azure/azure-relay-bridge/blob/10645d4994cf27cd6d2adce5793b520089b526b4/src/azbridge/azbridge.csproj#L199

This PR also bumps the `PackagingTargets` package version to support Ubuntu 22