### PR TITLE
Adding HTTP reverse proxy support

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -147,6 +147,25 @@ is no separate command-line flag.
 Quiet mode.  Causes most warning and diagnostic messages to be
 suppressed.
 
+**-H relay_name:http/hostport{;...}**<br/>
+**-H relay_name:http/host[/path]:hostport{;...}**<br/>
+**-H relay_name:https/hostport{;...}**<br/>
+**-H relay_name:https/host[/path]:hostport{;...}**<br/>
+
+Specifies that HTTP requests to the given Azure Relay name
+are to be forwarded to the given host and port. For any Relay 
+name, this is mutually exclusive with the use of the -T option. 
+
+The required logical port names "http" and "https" indicate which protocol
+shall be used when forwarding requests to the target.  
+
+- `relay_name`: Name of the relay to bind the forwarder to.
+- `host`: Host name or IP address to forward to.
+- `path` : Path prefix to append to the outgoing requests. The relay name 
+   is stripped.
+- `hostport`: TCP port number. (defaults to 443 for https and 80 for http)
+
+
 **-T relay_name:[port_name/]hostport{;...}**<br/>
 **-T relay_name:[port_name/]host:hostport{;...}**<br/>
 **-T relay_name:[port_name/]local_socket{;...}**
@@ -162,9 +181,9 @@ or local_socket, from the local machine.
 
 - `relay_name`: Name of the relay to bind the forwarder to.
 - `port_name`: Optional logical name for the port as defined by
-   the local forwarder bound to this relay (see -L).   
+   the local forwarder bound to this relay (see -L). 
 - `host`: Host name or IP address to forward to.
-- `port`: TCP or UDP port number. TCP ports are the default. 
+- `hostport`: TCP or UDP port number. TCP ports are the default. 
    UDP port numbers must be suffixed with `U`, 
    e.g. `-T relay:3434U`. UDP forwarders can only be bound to 
    logcial UDP ports.

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
@@ -36,16 +36,18 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
         public string SharedAccessKeyName { get; set; }
         [Option(CommandOptionType.SingleValue, ShortName = "k", Description = "Azure Relay shared access policy key")]
         public string SharedAccessKey { get; set; }
-        [Option(CommandOptionType.MultipleValue, ShortName = "L", Description = "Local forwarder [address:]port:relay_name")]
+        [Option(CommandOptionType.MultipleValue, ShortName = "L", Description = "Local forwarder [hostname:]port[/port_name]:relay_name")]
         public IEnumerable<string> LocalForward { get; set; }
         [Option(CommandOptionType.MultipleValue, ShortName = "o", Description = "Configuration file option override key:value")]
         public IEnumerable<string> Option { get; set; }
         [Option(CommandOptionType.NoValue, ShortName = "q", Description = "No log output to stdout/stderr")]
         public bool? Quiet { get; set; }
-        [Option(CommandOptionType.MultipleValue, ShortName = "R", Description = "Remote forwarder relay_name:[address:]port ", ShowInHelpText = false)]
+        [Option(CommandOptionType.MultipleValue, ShortName = "R", Description = "Remote forwarder relay_name:[hostname:]port ", ShowInHelpText = false)]
         public IEnumerable<string> RemoteForwardOld { get; set; }
-        [Option(CommandOptionType.MultipleValue, ShortName = "T", Description = "Remote forwarder relay_name:[address:]port ")]
+        [Option(CommandOptionType.MultipleValue, ShortName = "T", Description = "Remote forwarder relay_name:[port_name/][hostname:]port ")]
         public IEnumerable<string> RemoteForward { get; set; }
+        [Option(CommandOptionType.MultipleValue, ShortName = "H", Description = "Remote HTTP(S) forwarder relay_name:{http|https}/[hostname:]port ")]
+        public IEnumerable<string> RemoteHttpForward { get; set; }
         [Option(CommandOptionType.SingleValue, ShortName = "s", Description = "Azure Relay shared access signature token")]
         public string Signature { get; set; }
 

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
             {
                 var val = value != null ? value.Trim('\'', '\"') : value;
                 if (val != null &&
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !new Regex("^[0-9A-Za-z/_-]+$").Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(RelayName),
@@ -144,7 +144,12 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
                     bindings[0].HostPort = value;
                 }
             }
-        }                               
+        }
+
+        public bool Http
+        {
+            get; set;
+        }
 
 
         public string LocalSocket

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
@@ -12,7 +12,7 @@
         int hostPort;
         string localSocket = null;
         string portName;
-
+      
         public string Host
         {
             get => host;
@@ -95,6 +95,18 @@
                 }
                 localSocket = val;
             }
+        }
+
+        public bool Http 
+        {
+            get; 
+            set; 
+        }
+        
+        public string Path 
+        { 
+            get; 
+            internal set; 
         }
     }
 }

--- a/src/Microsoft.Azure.Relay.Bridge/IRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/IRemoteForwarder.cs
@@ -9,5 +9,11 @@ namespace Microsoft.Azure.Relay.Bridge
     {
         string PortName { get; }
         Task HandleConnectionAsync(HybridConnectionStream hybridConnectionStream);
+        
+    }
+
+    interface IRemoteRequestForwarder : IRemoteForwarder
+    {
+        Task HandleRequest(RelayedHttpListenerContext ctx);
     }
 }

--- a/src/Microsoft.Azure.Relay.Bridge/RemoteForwardHost.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/RemoteForwardHost.cs
@@ -105,8 +105,13 @@ namespace Microsoft.Azure.Relay.Bridge
                     var remoteForwarders = new Dictionary<string, IRemoteForwarder>();
                     foreach (var binding in remoteForward.Bindings)
                     {
-#if !NETFRAMEWORK
-                        if (!string.IsNullOrEmpty(binding.LocalSocket))
+                        if (binding.Http)
+                        {
+                            var tcpRemoteForwarder =
+                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http);
+                            remoteForwarders.Add(tcpRemoteForwarder.PortName, tcpRemoteForwarder);
+                        }
+                        else if (!string.IsNullOrEmpty(binding.LocalSocket))
                         {
                             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
                             {
@@ -118,12 +123,10 @@ namespace Microsoft.Azure.Relay.Bridge
                                 new SocketRemoteForwarder(binding.PortName, binding.LocalSocket);
                             remoteForwarders.Add(socketRemoteForwarder.PortName, socketRemoteForwarder);
                         }
-                        else
-#endif
-                        if (binding.HostPort > 0)
+                        else if (binding.HostPort > 0)
                         {
                             var tcpRemoteForwarder =
-                                new TcpRemoteForwarder(this.config, binding.PortName, binding.Host, binding.HostPort);
+                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http);
                             remoteForwarders.Add(tcpRemoteForwarder.PortName, tcpRemoteForwarder);
                         }
                         else if (binding.HostPort < 0)

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
@@ -47,6 +47,11 @@ namespace Microsoft.Azure.Relay.Bridge.Test
                    " -T bar2:10.1.1.1:123" +
                    " -T foo4:port/123" +
                    " -T bar4:port/10.1.1.1:123" +
+                   " -H foo5:https/service.example.com" +
+                   " -H bar5:http/service.example.com:81" +
+                   " -H baz5:http/service.example.com" +
+                   " -H abc/def:http/service.example.com/foo" +
+                   " -H ghi/jkl:http/service1.example.com/foo;http/service2.example.com/foo" +
                    " -v";
         }
 
@@ -624,7 +629,7 @@ namespace Microsoft.Azure.Relay.Bridge.Test
             Assert.Equal("name", config.LocalForward[2].BindLocalSocket);
             Assert.Equal("baz", config.LocalForward[2].RelayName);
 
-            Assert.Equal(9, config.RemoteForward.Count);
+            Assert.Equal(14, config.RemoteForward.Count);
             Assert.Equal("foo1", config.RemoteForward[0].RelayName);
             Assert.Equal(123, config.RemoteForward[0].HostPort);
             Assert.Equal("bar1", config.RemoteForward[1].RelayName);
@@ -651,6 +656,34 @@ namespace Microsoft.Azure.Relay.Bridge.Test
             Assert.Equal(123, config.RemoteForward[8].HostPort);
             Assert.Equal("10.1.1.1", config.RemoteForward[8].Host);
             Assert.Equal("port", config.RemoteForward[8].PortName);
+            Assert.Equal("foo5", config.RemoteForward[9].RelayName);
+            Assert.Equal(443, config.RemoteForward[9].HostPort);
+            Assert.Equal("https", config.RemoteForward[9].PortName);
+            Assert.Equal("service.example.com", config.RemoteForward[9].Host);
+            Assert.Equal("bar5", config.RemoteForward[10].RelayName);
+            Assert.Equal(81, config.RemoteForward[10].HostPort);
+            Assert.Equal("http", config.RemoteForward[10].PortName);
+            Assert.Equal("service.example.com", config.RemoteForward[10].Host);
+            Assert.Equal("baz5", config.RemoteForward[11].RelayName);
+            Assert.Equal(80, config.RemoteForward[11].HostPort);
+            Assert.Equal("http", config.RemoteForward[11].PortName);
+            Assert.Equal("service.example.com", config.RemoteForward[11].Host);
+            Assert.Equal("abc/def", config.RemoteForward[12].RelayName);
+            Assert.Equal(80, config.RemoteForward[12].Bindings[0].HostPort);
+            Assert.Equal("http", config.RemoteForward[12].Bindings[0].PortName);
+            Assert.Equal("service.example.com", config.RemoteForward[12].Bindings[0].Host);
+            Assert.Equal("/foo/", config.RemoteForward[12].Bindings[0].Path);
+            Assert.Equal("ghi/jkl", config.RemoteForward[13].RelayName);
+            Assert.Equal(80, config.RemoteForward[13].Bindings[0].HostPort);
+            Assert.Equal("http", config.RemoteForward[13].Bindings[0].PortName);
+            Assert.Equal("service1.example.com", config.RemoteForward[13].Bindings[0].Host);
+            Assert.Equal("/foo/", config.RemoteForward[13].Bindings[1].Path);
+            Assert.Equal(80, config.RemoteForward[13].Bindings[1].HostPort);
+            Assert.Equal("http", config.RemoteForward[13].Bindings[1].PortName);
+            Assert.Equal("service2.example.com", config.RemoteForward[13].Bindings[1].Host);
+            Assert.Equal("/foo/", config.RemoteForward[13].Bindings[1].Path);
+
+            Assert.True(config.RemoteForward[10].Http);
 
 
         }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>rel</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
-H option added, which allows for HTTP request proxying using the Relay as the public endpoint without requiring a client side bridge (but yet AuthZ at the Relay unless turned off).