### PR TITLE
Create a release when a tag is pushed.

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -60,15 +60,11 @@ jobs:
       env:
          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
       run: bash ./verify-build.sh
-    
-    - name: Upload Binaries to the Release
-      uses: svenstaro/upload-release-action@v2
+      
+    # create a release if a tag has been pushed
+    - uses: ncipollo/release-action@v1
       if: startsWith(github.ref, 'refs/tags/v')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: artifacts/build/net6.0/*
-        file_glob: true
-        tag: ${{ github.ref }}
-        overwrite: true
+        artifacts: "artifacts/build/net6.0/*"
+        generateReleaseNotes: true      
+    

--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -62,7 +62,8 @@ jobs:
       run: bash ./verify-build.sh
       
     # create a release if a tag has been pushed
-    - uses: ncipollo/release-action@v1
+    - name: Generate Release
+      uses: ncipollo/release-action@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
         artifacts: "artifacts/build/net6.0/*"


### PR DESCRIPTION
When a tag is pushed creates a release (using tag as the version and title).

Release notes are automatically generated using [built in capabilities](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

Artifacts are added to release as downloadable assets

You may want to configure the [change notes format](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) with a `.github/release.yml` file.

There may be two other parameters you may want to set to have a different behavior:

- **removeArtifacts** Indicates if existing release artifacts should be removed (default value false)
- **allowUpdates** An optional flag which indicates if we should update a release if it already exists. Defaults to false. (default value false)