### PR TITLE
live unit tests

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -77,9 +77,13 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     
     - name: Unit Test Windows x64
+      env:
+         AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
       run: dotnet test /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x64 /p:Configuration=Debug
       if: matrix.os == 'windows-latest'
-    - name: Unit Test Windows x64
+    - name: Unit Test Ubuntu 20.04
+      env:
+         AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
       run: dotnet test /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-x64 /p:Configuration=Debug
       if: matrix.os == 'ubuntu-latest'
 

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/BridgeTest.cs
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/BridgeTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Relay.Bridge.Test
             this.launchSettingsFixture = launchSettingsFixture;
         }
 
-        [Fact(Skip = "true")]
+        [Fact]
         public void TcpBridge()
         {
             // set up the bridge first
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Relay.Bridge.Test
             }
         }
 
-        [Fact(Skip = "true")]
+        [Fact]
         public void UdpBridge()
         {
             // set up the bridge first
@@ -157,8 +157,8 @@ namespace Microsoft.Azure.Relay.Bridge.Test
             }
         }
 
-#if !NETFRAMEWORK
-        [Fact(Skip = "true")]
+#if !_WINDOWS
+        [Fact]
         public void SocketBridge()
         {
             // not yet supported on Windows.
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Relay.Bridge.Test
         }
 #endif
 
-        [Fact(Skip = "true")]
+        [Fact]
         public void TcpBridgeBadListener()
         {
             // set up the bridge first

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/Utilities.cs
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/Utilities.cs
@@ -13,7 +13,12 @@ namespace Microsoft.Azure.Relay.Bridge.Test
 
         internal static string GetConnectionString()
         {
-            return Environment.GetEnvironmentVariable("AZBRIDGE_TEST_CXNSTRING")?.Trim('\"');
+            string cxn = Environment.GetEnvironmentVariable("AZBRIDGE_TEST_CXNSTRING")?.Trim('\"');
+            if (string.IsNullOrEmpty(cxn))
+            {
+                throw new InvalidOperationException("The AZBRIDGE_TEST_CXNSTRING environment string must be set to a preconfigured Relay namespace for this test to execute");
+            }
+            return cxn;
         }
     }
 }


### PR DESCRIPTION
Unit tests now require AZBRIDGE_TEST_CXNSTRING environment variable set to a connection string set to a relay namespace that has preconfigured hybrid connections "a1", "a2", "a3", "a4"

Signed-off-by: Clemens Vasters <clemensv@microsoft.com>