### PR TITLE
A single remote forwarder will now map to all logical ports

### DIFF
--- a/src/Microsoft.Azure.Relay.Bridge/RemoteForwardBridge.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/RemoteForwardBridge.cs
@@ -193,7 +193,20 @@ namespace Microsoft.Azure.Relay.Bridge
                         return;
                     }
 
-                    if (remoteForwarders.TryGetValue(portName, out var forwarder))
+                    IRemoteForwarder forwarder = null;                    
+                    if (remoteForwarders.Count == 1)
+                    {
+                        forwarder = remoteForwarders.Values.First();
+                    }
+                    else
+                    {
+                        if (!remoteForwarders.TryGetValue(portName, out forwarder))
+                        {
+                            forwarder = null;
+                        }
+                    }
+
+                    if ( forwarder != null)
                     {
                         if (forwarder is UdpRemoteForwarder && versionPreamble[2] != 1)
                         {

--- a/src/Microsoft.Azure.Relay.Bridge/RemoteForwardBridge.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/RemoteForwardBridge.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     }
 
                     IRemoteForwarder forwarder = null;                    
-                    if (remoteForwarders.Count == 1)
+                    if (remoteForwarders.Count == 1 && int.TryParse(portName, out var port))
                     {
                         forwarder = remoteForwarders.Values.First();
                     }

--- a/src/Microsoft.Azure.Relay.Bridge/StreamPump.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/StreamPump.cs
@@ -24,14 +24,14 @@ namespace Microsoft.Azure.Relay.Bridge
                 {
                     int bytesRead;
 
-                    bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+                    bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
                     
                     if (bytesRead == 0)
                     {
                         shutdownAction?.Invoke();
                         return;
                     }
-                    await target.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                    await target.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Relay.Bridge
                     // pick one of those eligible endpoints
                     client.Client.Bind(new IPEndPoint(eligibleAddresses[rnd.Next(eligibleAddresses.Count)], 0));
                 }
-                await client.ConnectAsync(targetServer, targetPort);
+                await client.ConnectAsync(targetServer, targetPort).ConfigureAwait(false);
                 var tcpstream = client.GetStream();
 
                 BridgeEventSource.Log.RemoteForwardTcpSocketAccepted(handleConnectionActivity, $"{targetServer}:{targetPort}");


### PR DESCRIPTION
If you provide a single remote forwarder with -T relay:port, that forwarder will now map to any ports coming from the requesting local forwarder, as long as those port names are plain TCP or UDP ports (numeric)