### PR TITLE
fixed command line options of HTTP Scenario schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ can have.
                       Namespace
 
                                  azbridge \
-                                   -H latavola/https:443 \
+                                   -H latavola:https/443 \
                                    -e sb://mydemo.servicebus.windows.net
 ```
 


### PR DESCRIPTION
Now it's "-H latavola:https/443 \"  as stated in Command Line Options example "-H relay_name:https/hostport{;...}"  [ https://github.com/Azure/azure-relay-bridge/blob/master/CONFIG.md ]