### PR TITLE
feat: publish docker image

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -128,4 +128,18 @@ jobs:
         artifacts: "artifacts/build/net6.0/*,artifacts/build/images/*"
         generateReleaseNotes: true
         allowUpdates: true
-    
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Push to GitHub Container Registry  
+      run: |  
+        ORG_NAME=$(echo "${{ github.repository_owner }}" | awk '{print tolower($0)}')
+        docker tag azbridge:${{ env.PRODVERSION }} ghcr.io/$ORG_NAME/azure-relay-bridge:${{ env.PRODVERSION }}.${{ env.PATCHVERSION }}
+        docker push ghcr.io/$ORG_NAME/azure-relay-bridge:${{ env.PRODVERSION }}.${{ env.PATCHVERSION }}
+      if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Hey there,

I've been playing around with the repo and thought about how it would be so much nicer if we didn't have to manually build the Docker image ourselves. So, I went ahead and made some tweaks to our GitHub Actions workflow. Now, it will automatically build and push the Docker image for us.

Let me know what you think. If you have any suggestions or improvements, I'm all ears.

Cheers,
Linckez