### PR TITLE
Upgrade to .Net 8

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     
     - name: Restore dependencies
       run: dotnet restore
@@ -49,58 +49,43 @@ jobs:
          docker save azbridge:${{ env.PRODVERSION }} > artifacts/build/images/azbridge-oci-image-${{ env.PRODVERSION }}.${{ env.PATCHVERSION }}.tar
       if: matrix.os == 'ubuntu-latest'
 
-    - name: Build for Windows 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=true /p:RuntimeIdentifier=win10-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for Windows-x64
+      run: dotnet msbuild /t:Package /p:WindowsOnly=true /p:RuntimeIdentifier=win-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'windows-latest'
-    - name: Build for Windows 10-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-arm /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for Windows-arm64
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-arm /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'windows-latest'
-    - name: Build for Windows 10-x86
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win10-x86 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for Windows-x86
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-x86 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'windows-latest'
     - name: Build for macOS-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'ubuntu-latest'
-    - name: Build for Ubuntu 18-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for macOS-arm64
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'ubuntu-latest'
-    - name: Build for Ubuntu 18-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.18.04-arm64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for Linux-x64
+      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'ubuntu-latest'
-    - name: Build for Ubuntu 20-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.20.04-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for Ubuntu 20-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=ubuntu.20.04-arm64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for Debian 10-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=debian.10-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for OpenSUSE 15-x64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=opensuse.15.0-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for Fedora 30-x64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=fedora.34-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for CentOS 9-x64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=centos.9-x64 /p:Configuration=Release /p:TargetFramework=net6.0 /p:VersionSuffix=rel
+    - name: Build for Linux-arm64
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'ubuntu-latest'
         
     - name: Unit Test Windows x64
       env:
          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-      run: dotnet test /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x64 /p:Configuration=Debug
+      run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 /p:Configuration=Debug
       if: matrix.os == 'windows-latest'
-    - name: Unit Test Ubuntu 20.04
+    - name: Unit Test Linux x64
       env:
          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-      run: dotnet test /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-x64 /p:Configuration=Debug
+      run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-x64 /p:Configuration=Debug
       if: matrix.os == 'ubuntu-latest'
 
     - uses: actions/upload-artifact@v2
       with:
         name: XBuild
-        path: artifacts/build/net6.0
+        path: artifacts/build/net8.0
     
     - uses: actions/upload-artifact@v2
       with:
@@ -125,7 +110,7 @@ jobs:
       uses: ncipollo/release-action@v1
       if: startsWith(github.ref, 'refs/tags/v')
       with:
-        artifacts: "artifacts/build/net6.0/*,artifacts/build/images/*"
+        artifacts: "artifacts/build/net8.0/*,artifacts/build/images/*"
         generateReleaseNotes: true
         allowUpdates: true
     

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'net6.0' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'net8.0' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
     <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
     <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 as publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0 as publish
 
 # ENV http_proxy=http://proxy.corporation.example:8080
 # ENV https_proxy=http://proxy.corporation.example:8080
 COPY . /azure-relay-bridge/
 WORKDIR /azure-relay-bridge/src/azbridge
-RUN dotnet publish azbridge.csproj -c Release -f net6.0 -p:SelfContained=false -r ubuntu-x64  -p:PublishTrimmed=false -o /app
+RUN dotnet publish azbridge.csproj -c Release -f net8.0 -p:SelfContained=false -r linux-x64  -p:PublishTrimmed=false -o /app
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0
-ARG REVISION=0.6.0
-ARG VERSION=0.6
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+ARG REVISION=0.9.0
+ARG VERSION=0.9
 LABEL org.opencontainers.image.documentation="https://github.com/Azure/azure-relay-bridge/blob/master/README.md"
 LABEL org.opencontainers.image.source="https://github.com/Azure/azure-relay-bridge"
 LABEL org.opencontainers.image.url="https://github.com/Azure/azure-relay-bridge"
 LABEL org.opencontainers.image.authors="askservicebus@microsoft.com"
 LABEL org.opencontainers.image.title="Microsoft Azure Relay Bridge"
 LABEL org.opencontainers.image.description="CLI tool to create TCP, UDP, Sockets, and HTTP tunnels via proxies and firewalls using the Azure Relay service."
-LABEL org.opencontainers.image.base.name="mcr.microsoft.com/dotnet/runtime:6.0"
+LABEL org.opencontainers.image.base.name="mcr.microsoft.com/dotnet/runtime:8.0"
 LABEL org.opencontainers.image.revision=${REVISION}
 LABEL org.opencontainers.image.revision=${VERSION}
 WORKDIR /app

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -5,7 +5,7 @@
             "azbridge": {
                 "Exclusions": {
                   "DOC_MISSING": {
-                    "lib/net6.0/azbridge.dll": "no public API"
+                    "lib/net8.0/azbridge.dll": "no public API"
                   }
                 }
               }

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -225,7 +225,7 @@ The package install will put the tool into `/usr/share/azbridge`.
 
 You can also install the tool from respective platform *.tar.gz archive. For
 Linux, you need to [explicitly install Linux prerequisites for .NET
-6.0](https://docs.microsoft.com/en-us/dotnet/core/install/linux) for your
+8.0](https://docs.microsoft.com/en-us/dotnet/core/install/linux) for your
 respective distribution. For macOS, you need to [install prerequisites from this
 list](https://docs.microsoft.com/en-us/dotnet/core/install/macos).
 
@@ -238,12 +238,12 @@ built on Windows. You will at least need the "Build Tools for Visual Studio
 2022", and ideally a local install of Visual Studio 2022 with desktop C#
 support.
 
-All other versions are built with the .NET 6.0 SDK. The DEB and
+All other versions are built with the .NET 8.0 SDK. The DEB and
 RPM packages are only created when building on a Unix (i.e. Linux or macOS) host.
 
 The ideal build environment is a Windows host with Docker for Windows installed.
 The `package-all.cmd` script will first build and package all Windows targets,
-and then launch a docker-based build with the official Microsoft .NET Core 6.0
+and then launch a docker-based build with the official Microsoft .NET Core 8.0
 SDK image for the remaining targets. The `package.sh` script will only build and
 package the Unix targets, the `package.cmd` script only Windows targets. The
 `build.cmd` and `build.sh` scripts only build the project without packaging.

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
     <WixPackageVersion>3.11.2</WixPackageVersion>
     <MicrosoftDiagnosticsTracingEventSourcePackageVersion>1.1.28</MicrosoftDiagnosticsTracingEventSourcePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.66</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
-    <MicrosoftNETCoreAppPackageVersion>6.0.0</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>8.0.0</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNetHttpHeadersPackageVersion>2.2.8</MicrosoftNetHttpHeadersPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>17.3.0</MicrosoftNETTestSdkPackageVersion>
     <SystemNetNetworkInformationPackageVersion>4.3.0</SystemNetNetworkInformationPackageVersion>
@@ -16,7 +16,7 @@
     <SystemIOPackageVersion>4.3.0</SystemIOPackageVersion>
     <SystemMemoryPackageVersion>4.5.5</SystemMemoryPackageVersion>
     <SystemDiagnosticsTracingPackageVersion>4.3.0</SystemDiagnosticsTracingPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemNetHttpPackageVersion>4.3.4</SystemNetHttpPackageVersion>
     <SystemNetNameResolutionPackageVersion>4.3.0</SystemNetNameResolutionPackageVersion>
     <YamlDotNetPackageVersion>12.0.0</YamlDotNetPackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <PackagingTargetsPackageVersion>0.1.220</PackagingTargetsPackageVersion>
-    <WixPackageVersion>3.11.2</WixPackageVersion>
+    <WixPackageVersion>3.14.0</WixPackageVersion>
     <MicrosoftDiagnosticsTracingEventSourcePackageVersion>1.1.28</MicrosoftDiagnosticsTracingEventSourcePackageVersion>
     <MicrosoftDiagnosticsTracingTraceEventPackageVersion>2.0.66</MicrosoftDiagnosticsTracingTraceEventPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>8.0.0</MicrosoftNETCoreAppPackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,17 +1,17 @@
 ﻿<Project>
 	<PropertyGroup>
 		<WindowsOnly>false</WindowsOnly>
-		<CoreFrameworks>net6.0</CoreFrameworks>
+		<CoreFrameworks>net8.0</CoreFrameworks>
 		<TargetFrameworks>$(CoreFrameworks)</TargetFrameworks>
-		<TargetFramework Condition="'$(TargetFramework)'==''">net6.0</TargetFramework>
-		<WindowsRuntimeIdentifiers Condition="'$(OS)'=='Windows_NT'">win10-x64;win10-x86;win10-arm64;</WindowsRuntimeIdentifiers>
-		<UnixRuntimeIdentifiers Condition="'$(WindowsOnly)'=='false'">osx-x64;debian.10-x64;ubuntu.18.04-x64;ubuntu.18.04-arm64;ubuntu.20.04-x64;ubuntu.20.04-arm64;opensuse.15.0-x64;fedora.34-x64;centos.9-x64</UnixRuntimeIdentifiers>
+		<TargetFramework Condition="'$(TargetFramework)'==''">net8.0</TargetFramework>
+		<WindowsRuntimeIdentifiers Condition="'$(OS)'=='Windows_NT'">win-x64;win-x86;win-arm64;</WindowsRuntimeIdentifiers>
+		<UnixRuntimeIdentifiers Condition="'$(WindowsOnly)'=='false'">osx-x64;osx-arm64;linux-x64;linux-arm64</UnixRuntimeIdentifiers>
 		<RuntimeIdentifiers>$(WindowsRuntimeIdentifiers)$(UnixRuntimeIdentifiers)</RuntimeIdentifiers>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(OS)' == 'Windows_NT' OR $(RuntimeIdentifier.StartsWith('win'))">
 		<DefineConstants>_WINDOWS</DefineConstants>
 	</PropertyGroup>
-	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('ubuntu')) OR $(RuntimeIdentifier.StartsWith('debian')) OR $(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('centos')) OR $(RuntimeIdentifier.StartsWith('fedora')) ">
+	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<DefineConstants>_SYSTEMD</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>

--- a/package-all.cmd
+++ b/package-all.cmd
@@ -10,27 +10,22 @@ echo *** Building and packaging Windows Targets
 
 if %_DOCKER_BUILD% == "true" (
    echo *** Windows only
-   dotnet msbuild /t:restore,package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x64 %*
-   dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-arm64 %*
-   dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x86 %*
+   dotnet msbuild /t:restore,package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 %*
+   dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-arm64 %*
+   dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x86 %*
 ) else (
     echo *** All platforms
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-arm64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net6.0 /p:RuntimeIdentifier=win10-x86 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=osx-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=debian.10-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.18.04-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.18.04-arm64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-arm64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=opensuse.15.0-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=fedora.34-x64 %*
-    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=centos.9-x64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-arm64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=true /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x86 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-x64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-arm64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-x64 %*
+    dotnet msbuild /t:restore,Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-arm64 %*
 )
 
 if not errorlevel 0 exit /b 1
 if %_DOCKER_BUILD% == "true" (
   echo *** Building and packaging Unix/Linux Targets
-  docker run --rm -v %cd%:/build mcr.microsoft.com/dotnet/sdk:6.0 /build/package.sh %*
+  docker run --rm -v %cd%:/build mcr.microsoft.com/dotnet/sdk:8.0 /build/package.sh %*
 )

--- a/package.sh
+++ b/package.sh
@@ -2,14 +2,8 @@
 pushd "${0%/*}" > /dev/null 
 if [ ! -z $BUILDVERSION ]; then _VersionProp="/p:VersionPrefix=$BUILDVERSION"; fi
 dotnet restore
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=osx-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=debian.10-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.18.04-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.18.04-arm64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=ubuntu.20.04-arm64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=opensuse.15.0-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=fedora.34-x64 $_BuildProp $_VersionProp $@
-dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net6.0 /p:RuntimeIdentifier=centos.9-x64 $_BuildProp $_VersionProp $@
-
+dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-x64 $_BuildProp $_VersionProp $@
+dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-arm64 $_BuildProp $_VersionProp $@
+dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-x64 $_BuildProp $_VersionProp $@
+dotnet msbuild /t:Package /p:Configuration=Release /p:WindowsOnly=false /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-arm64 $_BuildProp $_VersionProp $@
 popd

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/ConfigException.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/ConfigException.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
             FileName = fileName;
         }
 
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
         protected ConfigException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
+++ b/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
@@ -2,7 +2,7 @@
 
 <PropertyGroup>
       <DisableOutOfProcTaskHost>true</DisableOutOfProcTaskHost>
-      <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win10-x64</RuntimeIdentifier>
+      <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -13,7 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.1" />
+    <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtilsPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Relay" Version="$(MicrosoftAzureRelayPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
@@ -53,7 +57,7 @@
 
   <Target Name="GetTargetPath" Returns="@(WixGetTargetPath)">
     <ItemGroup>
-      <WixGetTargetPath Include="$(MSBuildProjectDirectory)\$(OutputPath)\net6.0\$(AssemblyName).dll" />
+      <WixGetTargetPath Include="$(MSBuildProjectDirectory)\$(OutputPath)\net8.0\$(AssemblyName).dll" />
     </ItemGroup>
   </Target>
 

--- a/src/azbridge-installer/azbridge-installer.wixproj
+++ b/src/azbridge-installer/azbridge-installer.wixproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Publish" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\WiX.3.11.2\build\wix.props" Condition="Exists('packages\WiX.3.11.2\build\wix.props')" />
+  <Import Project="packages\WiX.3.14.0\build\wix.props" Condition="Exists('packages\WiX.3.14.0\build\wix.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProductVersion>3.10</ProductVersion>
@@ -82,7 +82,7 @@
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
-    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+    <Error Text="The WiX Toolset v3.14 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
   <Target Name="BeforeBuild">
      <Exec Command="dotnet publish $(BridgeProjectFile) -c $(Configuration) -f $(TargetFramework) -r $(RuntimeIdentifier)" 
@@ -98,7 +98,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WiX.3.11.2\build\wix.props'))" />
+    <Error Condition="!Exists('packages\WiX.3.14.0\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\WiX.3.14.0\build\wix.props'))" />
   </Target>
   <Target Name="Publish" DependsOnTargets="Build">
   </Target>

--- a/src/azbridge-installer/build.cmd
+++ b/src/azbridge-installer/build.cmd
@@ -1,1 +1,1 @@
-msbuild /t:publish /p:AlreadyPublished=true /p:TargetFramework=net6.0 /p:Platform=x64 /p:Configuration=Debug /p:RuntimeIdentifier=win10-x64
+msbuild /t:publish /p:AlreadyPublished=true /p:TargetFramework=net8.0 /p:Platform=x64 /p:Configuration=Debug /p:RuntimeIdentifier=win-x64

--- a/src/azbridge-installer/packages.config
+++ b/src/azbridge-installer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WiX" version="3.11.2" targetFramework="net6.0" />
+  <package id="WiX" version="3.11.2" targetFramework="net8.0" />
 </packages>

--- a/src/azbridge-installer/packages.config
+++ b/src/azbridge-installer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WiX" version="3.11.2" targetFramework="net8.0" />
+  <package id="WiX" version="3.14.0" targetFramework="net8.0" />
 </packages>

--- a/src/azbridge-installer/restore.cmd
+++ b/src/azbridge-installer/restore.cmd
@@ -8,7 +8,7 @@ REM
 @echo off
 pushd "%~dp0"
 if not exist ".\.nuget" mkdir ".\.nuget"
-if not exist ".\.nuget\nuget.exe" powershell -Command "Invoke-WebRequest https://www.nuget.org/nuget.exe -OutFile .\.nuget\nuget.exe"
+if not exist ".\.nuget\nuget.exe" powershell -Command "Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\.nuget\nuget.exe"
 if not exist ".\.nuget\nuget.config" (
     echo ^<?xml version="1.0" encoding="utf-8"?^> > .\.nuget\nuget.config
     echo ^<configuration^>^<packageSources^> >> .\.nuget\nuget.config

--- a/src/azbridge/azbridge.csproj
+++ b/src/azbridge/azbridge.csproj
@@ -5,12 +5,13 @@
 		<DisableOutOfProcTaskHost>true</DisableOutOfProcTaskHost>
 		<SelfContained>true</SelfContained>
 		<PublishReadyToRunComposite>false</PublishReadyToRunComposite>
-		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win10-x64</RuntimeIdentifier>
+		<RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
 		<InvariantGlobalization>true</InvariantGlobalization>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<RuntimeHostConfigurationOption Include="System.Globalization.Invariant" Value="true" />
+		<RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -67,7 +68,7 @@
 		</Content>
 		<Content Include="azbridge.sh" CopyToPublishDirectory="PreserveNewest" Condition="! $(RuntimeIdentifier.StartsWith('win'))" RemoveOnUninstall="true">
 			<LinuxPath>/etc/profile.d/azbridge.sh</LinuxPath>
-			<LinuxFileMode Condition="!($(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('fedora')) OR $(RuntimeIdentifier.StartsWith('opensuse')) OR $(RuntimeIdentifier.StartsWith('centos')))">0555</LinuxFileMode>
+			<LinuxFileMode Condition="$(RuntimeIdentifier.StartsWith('linux'))">0555</LinuxFileMode>
 		</Content>
 		<Content Include="../tools/Powershell/add-hostname.ps1" CopyToPublishDirectory="PreserveNewest" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
 		<Content Include="../tools/Powershell/remove-hostname.ps1" CopyToPublishDirectory="PreserveNewest" Condition="$(RuntimeIdentifier.StartsWith('win'))" />
@@ -104,13 +105,9 @@
 		</ProjectReference>
 	</ItemGroup>
 
-	<!-- Debian and Ubuntu -->
-	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('debian')) OR $(RuntimeIdentifier.StartsWith('ubuntu')) OR $(RuntimeIdentifier.StartsWith('linuxmint'))">
+	<!-- Linux -->
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<DebDependency Include="ca-certificates" Version="" />
-	</ItemGroup>
-
-	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('opensuse'))">
-		<RpmDotNetDependency Include="libopenssl1_0_0" Version="" />
 	</ItemGroup>
 
 	<!-- Linux Daemon install properties -->
@@ -139,20 +136,20 @@
 
 	<Target Name="GetTargetPath" Returns="@(WixGetTargetPath)">
 		<ItemGroup>
-			<WixGetTargetPath Include="$(MSBuildProjectDirectory)\$(OutputPath)\net6.0\$(AssemblyName).exe" />
+			<WixGetTargetPath Include="$(MSBuildProjectDirectory)\$(OutputPath)\net8.0\$(AssemblyName).exe" />
 		</ItemGroup>
 	</Target>
 
 	<Target Name="PackageZip" DependsOnTargets="CreateZip" Condition="$(RuntimeIdentifier.EndsWith($(PlatformTarget))) AND $(RuntimeIdentifier.StartsWith('win'))">
 		<Copy SourceFiles="$(ZipPath)" DestinationFolder="$(BuildDir)/$(TargetFramework)" />
 	</Target>
-	<Target Name="PackageTarball" DependsOnTargets="CreateTarball" Condition="('$(TargetFramework)' == 'net6.0') AND $(UnixRuntimeIdentifiers.Contains($(RuntimeIdentifier)))">
+	<Target Name="PackageTarball" DependsOnTargets="CreateTarball" Condition="('$(TargetFramework)' == 'net8.0') AND $(UnixRuntimeIdentifiers.Contains($(RuntimeIdentifier)))">
 		<Copy SourceFiles="$(TarballPath)" DestinationFolder="$(BuildDir)/$(TargetFramework)" />
 	</Target>
-	<Target Name="PackageDebian" DependsOnTargets="CreateDeb" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net6.0') AND ($(RuntimeIdentifier.StartsWith('ubuntu')) OR $(RuntimeIdentifier.StartsWith('debian')) OR $(RuntimeIdentifier.StartsWith('linuxmint')))">
+	<Target Name="PackageDebian" DependsOnTargets="CreateDeb" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net8.0') AND ($(RuntimeIdentifier.StartsWith('linux')))">
 		<Copy SourceFiles="$(DebPath)" DestinationFolder="$(BuildDir)/$(TargetFramework)" />
 	</Target>
-	<Target Name="PackageRpm" DependsOnTargets="CreateRpm" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net6.0') AND ($(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('centos')) OR $(RuntimeIdentifier.StartsWith('fedora')) OR $(RuntimeIdentifier.StartsWith('opensuse')) OR $(RuntimeIdentifier.StartsWith('ol')))">
+	<Target Name="PackageRpm" DependsOnTargets="CreateRpm" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net8.0') AND ($(RuntimeIdentifier.StartsWith('linux')))">
 		<Copy SourceFiles="$(RpmPath)" DestinationFolder="$(BuildDir)/$(TargetFramework)" />
 	</Target>
 	<Target Name="PackageWindows" DependsOnTargets="Publish" Condition="'$(OS)' == 'Windows_NT' AND $(RuntimeIdentifier.StartsWith('win')) AND $(RuntimeIdentifier.EndsWith($(PlatformTarget)))">
@@ -167,7 +164,7 @@
 		<Exec Command="&quot;$(VS160COMNTOOLS)..\..\MSBuild\Current\Bin\msbuild&quot; ../azbridge-installer/azbridge-installer.wixproj /t:Publish /p:TargetFramework=$(TargetFramework);RuntimeIdentifier=$(RuntimeIdentifier);BridgeProjectFile=$(MSBuildProjectFullPath);BridgePublishPath=$(MSBuildProjectDirectory)\$(PublishDir);OutputPath=$(MSBuildProjectDirectory)\$(MsiDir);OutputName=$(_OutputName);AlreadyPublished=true" />
 		<Copy SourceFiles="$(MSBuildProjectDirectory)\$(MsiDir)\$(_OutputName).msi" DestinationFolder="$(BuildDir)/$(TargetFramework)" />
 	</Target>
-	<Target Name="PackageOSX" DependsOnTargets="Publish" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net6.0') AND ($(RuntimeIdentifier.StartsWith('osx')))">
+	<Target Name="PackageOSX" DependsOnTargets="Publish" Condition="'$(OS)' == 'Unix' AND ('$(TargetFramework)' == 'net8.0') AND ($(RuntimeIdentifier.StartsWith('osx')))">
 
 	</Target>
 	<Target Name="PublishPackages" DependsOnTargets="PackageDebian;PackageRpm;PackageWindows;PackageOSX;PackageZip;PackageTarball" Condition=" '$(RuntimeIdentifier)' != ''">

--- a/test/mysql/Test.proj
+++ b/test/mysql/Test.proj
@@ -2,7 +2,7 @@
     <Import Project="Directory.Build.props" />
   <PropertyGroup>
     <OutputType>None</OutputType>
-    <RuntimeIdentifier>debian.10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ImageSuffix>deb</ImageSuffix>
   </PropertyGroup>
 

--- a/test/mysql/my.cnf
+++ b/test/mysql/my.cnf
@@ -1,6 +1,7 @@
 [mysqld]
 user=mysql
 default_authentication_plugin=mysql_native_password
+connect_timeout=100
 
 [mysql]
 user=mysql

--- a/test/mysql/mysql.server.dockerfile
+++ b/test/mysql/mysql.server.dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5-debian AS build
+FROM mysql:8.0-debian AS build
 ARG package_name
 COPY ./tmp/$package_name .
 RUN apt-get -qq update -y

--- a/test/mysql/test.cmd
+++ b/test/mysql/test.cmd
@@ -10,11 +10,11 @@ if not "%~5" == "" set VersionSuffix=%~5
 if not "%~6" == "" set TargetFramework=%~6
 
 if "%Operation%"=="" set Operation=build
-if "%ImageName%"=="" set ImageName=ubuntu.18.04-x64
+if "%ImageName%"=="" set ImageName=linux-x64
 if "%ImageSuffix%"=="" set ImageSuffix=deb
 if "%VersionSuffix%"=="" set VersionSuffix=preview
 if "%VersionPrefix%"=="" set VersionPrefix=1.0.0
-if "%TargetFramework%"=="" set TargetFramework=net6.0
+if "%TargetFramework%"=="" set TargetFramework=net8.0
 
 set PackageName=azbridge.%VersionPrefix%-%VersionSuffix%.%ImageName%.%ImageSuffix%
 pushd "%~dp0"

--- a/test/mysql/test.sh
+++ b/test/mysql/test.sh
@@ -8,11 +8,11 @@ if [ ! -z $5 ]; then VersionSuffix=$5; fi
 if [ ! -z $6 ]; then TargetFramework=$6; fi
 
 if [ -z ${Operation+x} ]; then Operation='build'; fi
-if [ -z ${ImageName+x} ]; then ImageName='ubuntu.20.04-x64'; fi
+if [ -z ${ImageName+x} ]; then ImageName='linux-x64'; fi
 if [ -z ${ImageSuffix+x} ]; then VersionSuffix='deb'; fi
 if [ -z ${VersionSuffix+x} ]; then VersionSuffix='preview'; fi
 if [ -z ${VersionPrefix+x} ]; then VersionPrefix='1.0.0'; fi
-if [ -z ${TargetFramework+x} ]; then TargetFramework='net6.0'; fi
+if [ -z ${TargetFramework+x} ]; then TargetFramework='net8.0'; fi
 
 echo $@
 
@@ -52,8 +52,8 @@ else
         # start the web server
         server_name=$(docker run -v $(pwd):/tests -d -v $(pwd)/my.cnf:/etc/mysqld/conf.d/my.cnf --rm -d -e AZBRIDGE_TEST_CXNSTRING="$_CXNSTRING" -e MYSQL_ROOT_PASSWORD=PaSsWoRd112233 -e MYSQL_PASSWORD=PaSsWoRd112233 -e MYSQL_USER=mysql azbridge-mysql-server:latest)
         # wait for server to start
-        echo waiting 20 seconds
-        sleep 20
+        echo waiting 60 seconds
+        sleep 60
         # run the client
         docker run -v $(pwd):/tests -v $(pwd)/my.cnf:/home/mysql/.my.cnf --rm -i -e AZBRIDGE_TEST_CXNSTRING="$_CXNSTRING" azbridge-mysql-client:latest bash /tests/run_client.sh
         _RESULT=$?

--- a/test/nginx/Test.proj
+++ b/test/nginx/Test.proj
@@ -2,6 +2,7 @@
     <Import Project="Directory.Build.props" />
   <PropertyGroup>
     <OutputType>None</OutputType>
+    <UnixRuntimeIdentifiers>osx-x64;osx-arm64;debian.10-x64;ubuntu.18.04-x64;ubuntu.18.04-arm64;ubuntu.20.04-x64;ubuntu.20.04-arm64;opensuse.15.0-x64;fedora.34-x64;centos.9-x64</UnixRuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -10,15 +11,15 @@
     <ImageSuffix Condition="'$(ImageSuffix)' == ''">tar.gz</ImageSuffix>
   </PropertyGroup>
 
-  <Target Name="BuildImage" Condition=" '$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
+  <Target Name="BuildImage" Condition=" '$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.StartsWith('opensuse')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
       <Exec Command="test.cmd build &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;" Condition="'$(OS)'=='Windows_NT'"/>
       <Exec Command="bash ./test.sh build &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;" Condition="'$(OS)'=='Unix'"/>
   </Target>
-  <Target Name="VSTestImage" Condition=" '$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
+  <Target Name="VSTestImage" Condition=" '$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.StartsWith('opensuse')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
       <Exec Command="test.cmd test &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;"  Condition="'$(OS)'=='Windows_NT'"/>
       <Exec Command="bash ./test.sh test &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;" Condition="'$(OS)'=='Unix'"/>
   </Target>
-  <Target Name="CleanImage" Condition=" '$(RuntimeIdentifier)' != ''  AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
+  <Target Name="CleanImage" Condition=" '$(RuntimeIdentifier)' != ''  AND !$(RuntimeIdentifier.StartsWith('osx')) AND !$(RuntimeIdentifier.StartsWith('opensuse')) AND !$(RuntimeIdentifier.EndsWith('arm64'))">
       <Exec Command="test.cmd clean &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;" Condition="'$(OS)'=='Windows_NT'"/>
       <Exec Command="bash ./test.sh clean &quot;$(RuntimeIdentifier)&quot; &quot;$(ImageSuffix)&quot; &quot;$(VersionPrefix)&quot; &quot;$(VersionSuffix)&quot; &quot;$(TargetFramework)&quot;" Condition="'$(OS)'=='Unix'"/>
   </Target>

--- a/test/nginx/test.cmd
+++ b/test/nginx/test.cmd
@@ -10,11 +10,11 @@ if not "%~5" == "" set VersionSuffix=%~5
 if not "%~6" == "" set TargetFramework=%~6
 
 if "%Operation%"=="" set Operation=build
-if "%ImageName%"=="" set ImageName=ubuntu.18.04-x64
+if "%ImageName%"=="" set ImageName=linux-x64
 if "%ImageSuffix%"=="" set ImageSuffix=deb
 if "%VersionSuffix%"=="" set VersionSuffix=preview
 if "%VersionPrefix%"=="" set VersionPrefix=1.0.0
-if "%TargetFramework%"=="" set TargetFramework=net6.0
+if "%TargetFramework%"=="" set TargetFramework=net8.0
 
 pushd "%~dp0"
 

--- a/test/nginx/test.sh
+++ b/test/nginx/test.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
 if [ ! -z $1 ]; then Operation=$1; fi
-if [ ! -z $2 ]; then ImageName=$2; fi
+if [ ! -z $2 ]; then DistroName=$2; fi
 if [ ! -z $3 ]; then ImageSuffix=$3; fi
 if [ ! -z $4 ]; then VersionPrefix=$4; fi
 if [ ! -z $5 ]; then VersionSuffix=$5; fi
 if [ ! -z $6 ]; then TargetFramework=$6; fi
 
 if [ -z ${Operation+x} ]; then Operation='build'; fi
-if [ -z ${ImageName+x} ]; then ImageName='ubuntu.18.04-x64'; fi
+if [ -z ${DistroName+x} ]; then DistroName='debian.10-x64'; fi
 if [ -z ${ImageSuffix+x} ]; then VersionSuffix='deb'; fi
 if [ -z ${VersionSuffix+x} ]; then VersionSuffix='preview'; fi
 if [ -z ${VersionPrefix+x} ]; then VersionPrefix='1.0.0'; fi
-if [ -z ${TargetFramework+x} ]; then TargetFramework='net6.0'; fi
+if [ -z ${TargetFramework+x} ]; then TargetFramework='net8.0'; fi
+
+ImageName='linux-x64'
 
 echo $@
 
@@ -23,14 +25,14 @@ if [ "${Operation}" == "build" ]; then
     if [ ! -d "tmp" ]; then mkdir tmp; fi
   
     cp ../../artifacts/build/$TargetFramework/$PackageName tmp/ > /dev/null
-    docker build -q -f $ImageName.server.dockerfile . --tag azbridge-nginx-server-$ImageName --build-arg package_name=$PackageName
+    docker build -f $DistroName.server.dockerfile . --tag azbridge-nginx-server-$ImageName --build-arg package_name=$PackageName
     _RESULT=$?
     if [ $_RESULT -ne 0 ]; then
        rm -rf tmp
        popd
        exit $_RESULT
     fi
-    docker build -q -f $ImageName.client.dockerfile . --tag azbridge-nginx-client-$ImageName --build-arg package_name=$PackageName
+    docker build -q -f $DistroName.client.dockerfile . --tag azbridge-nginx-client-$ImageName --build-arg package_name=$PackageName
     _RESULT=$?
     if [ $_RESULT -ne 0 ]; then
        rm -rf tmp

--- a/test/node/Test.proj
+++ b/test/node/Test.proj
@@ -5,8 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ImageSuffix Condition="$(RuntimeIdentifier.StartsWith('debian')) OR $(RuntimeIdentifier.StartsWith('ubuntu')) OR $(RuntimeIdentifier.StartsWith('linuxmint'))">tar.gz</ImageSuffix>
-    <ImageSuffix Condition="$(RuntimeIdentifier.StartsWith('rhel')) OR $(RuntimeIdentifier.StartsWith('fedora')) OR $(RuntimeIdentifier.StartsWith('opensuse'))">tar.gz</ImageSuffix>
+    <ImageSuffix Condition="$(RuntimeIdentifier.StartsWith('linux')) OR $(RuntimeIdentifier.StartsWith('osx'))">tar.gz</ImageSuffix>
     <ImageSuffix Condition="'$(ImageSuffix)' == ''">zip</ImageSuffix>
   </PropertyGroup>
 

--- a/test/node/test.cmd
+++ b/test/node/test.cmd
@@ -10,11 +10,11 @@ if not "%~5" == "" set VersionSuffix=%~5
 if not "%~6" == "" set TargetFramework=%~6
 
 if "%Operation%"=="" set Operation=build
-if "%ImageName%"=="" set ImageName=ubuntu.18.04-x64
+if "%ImageName%"=="" set ImageName=linux-x64
 if "%ImageSuffix%"=="" set ImageSuffix=deb
 if "%VersionSuffix%"=="" set VersionSuffix=preview
 if "%VersionPrefix%"=="" set VersionPrefix=1.0.0
-if "%TargetFramework%"=="" set TargetFramework=net6.0
+if "%TargetFramework%"=="" set TargetFramework=net8.0
 
 pushd "%~dp0"
 

--- a/test/unit/Directory.Build.props
+++ b/test/unit/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <DeveloperBuildTestTfms>net6.0</DeveloperBuildTestTfms>
+    <DeveloperBuildTestTfms>net8.0</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/Microsoft.Azure.Relay.Bridge.Tests.csproj
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/Microsoft.Azure.Relay.Bridge.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <Description>Azure Relay Bridge Tests</Description>
-    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/verify-build.sh
+++ b/verify-build.sh
@@ -6,13 +6,13 @@ if [ -z $AZBRIDGE_TEST_CXNSTRING ]; then
 fi
 
 pushd test/mysql
-dotnet msbuild /t:build /p:Configuration=Debug /p:TargetFramework=net6.0 $_BuildProp $_VersionProp $@
+dotnet msbuild /t:build /p:Configuration=Debug /p:TargetFramework=net8.0 $_BuildProp $_VersionProp $@
 _RESULT=$?
 if [ $_RESULT -ne 0 ]; then 
     popd
     exit $_RESULT
 fi
-dotnet test --verbosity=normal /p:Configuration=Debug /p:TargetFramework=net6.0 $_BuildProp $_VersionProp $@
+dotnet test --verbosity=normal /p:Configuration=Debug /p:TargetFramework=net8.0 $_BuildProp $_VersionProp $@
 _RESULT=$?
 if [ $_RESULT -ne 0 ]; then 
     popd
@@ -20,13 +20,13 @@ if [ $_RESULT -ne 0 ]; then
 fi
 popd
 pushd test/nginx
-dotnet msbuild /t:clean,build /p:Configuration=Debug /p:TargetFramework=net6.0 $_BuildProp $_VersionProp $@
+dotnet msbuild /t:clean,build /p:Configuration=Debug /p:TargetFramework=net8.0 $_BuildProp $_VersionProp $@
 _RESULT=$?
 if [ $_RESULT -ne 0 ]; then 
     popd
     exit $_RESULT
 fi
-dotnet test --verbosity=normal /p:Configuration=Debug /p:TargetFramework=net6.0 $_BuildProp $_VersionProp $@
+dotnet test --verbosity=normal /p:Configuration=Debug /p:TargetFramework=net8.0 $_BuildProp $_VersionProp $@
 _RESULT=$?
 if [ $_RESULT -ne 0 ]; then
     popd

--- a/version.props
+++ b/version.props
@@ -3,7 +3,7 @@
   <RunNumber>0</RunNumber>  
   <RunNumber Condition="'$(GITHUB_RUN_NUMBER)'!=''">$(GITHUB_RUN_NUMBER)</RunNumber>
   <RunNumber Condition="'$(PATCHVERSION)'!=''">$(PATCHVERSION)</RunNumber>
-  <VersionPrefix>0.6.$(RunNumber)</VersionPrefix>
+  <VersionPrefix>0.9.$(RunNumber)</VersionPrefix>
   <VersionPrefix Condition="'$(PRODVERSION)'!=''">$(PRODVERSION).$(RunNumber)</VersionPrefix>
   <VersionSuffix>rel</VersionSuffix>
   <VersionSuffix Condition="'$(VERSIONSUFFIX)'!=''">$(VERSIONSUFFIX)</VersionSuffix>


### PR DESCRIPTION
Few things in this PR:
1) .Net 6.0 -> .Net 8.0 upgrade
2) `Azure.Identity` package upgraded to 10.2 (minimum version that has no vulnerability)
3) Added build for `osx-arm64`
4) WiX tools upgraded to 3.14

Breaking changes:
1) Due to the changes in how .Net 8 manages RIDs all Linux distro-specific packages are folded into 2 RPMs for x64/arm64 and 2 DEBs for x64/arm64
2) OpenSUSE users would need to install from tarball due to the way OpenSUSE names OpenSSL package which makes RPM  incompatible with it