### PR TITLE
Insecure mode for https forwarding

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -385,6 +385,7 @@ used on the same entry. For multiple bindings they can be used to form a list.
 * **HostPort** - TCP port on the host to forward to
 * **PortName** - Logical port name
 * **LocalSocket** - named UNIX socket forward to
+* **Insecure** - ignores certificate validation errors for https forwarding
 
 Examples:
 

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
@@ -102,7 +102,13 @@
             get; 
             set; 
         }
-        
+
+        public bool Insecure
+        {
+            get;
+            set;
+        }
+
         public string Path 
         { 
             get; 

--- a/src/Microsoft.Azure.Relay.Bridge/RemoteForwardHost.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/RemoteForwardHost.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Relay.Bridge
                         if (binding.Http)
                         {
                             var tcpRemoteForwarder =
-                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http);
+                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http, binding.Insecure);
                             remoteForwarders.Add(tcpRemoteForwarder.PortName, tcpRemoteForwarder);
                         }
                         else if (!string.IsNullOrEmpty(binding.LocalSocket))
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Relay.Bridge
                         else if (binding.HostPort > 0)
                         {
                             var tcpRemoteForwarder =
-                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http);
+                                new TcpRemoteForwarder(this.config, remoteForward.RelayName, binding.PortName, binding.Host, binding.HostPort, binding.Path, binding.Http, binding.Insecure);
                             remoteForwarders.Add(tcpRemoteForwarder.PortName, tcpRemoteForwarder);
                         }
                         else if (binding.HostPort < 0)

--- a/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Relay.Bridge
         private HttpClient httpClient;
         private string relaySubpath;
 
-        internal TcpRemoteForwarder(Config config, string relayName, string portName, string targetServer, int targetPort, string targetPath, bool http)
+        internal TcpRemoteForwarder(Config config, string relayName, string portName, string targetServer, int targetPort, string targetPath, bool http, bool insecure)
         {
             this.config = config;
             this.PortName = portName;
@@ -38,7 +38,12 @@ namespace Microsoft.Azure.Relay.Bridge
             
             if ( http )
             {
-                this.httpClient = new HttpClient();
+                var httpHandler = new HttpClientHandler();
+                if ( insecure )
+                {
+                    httpHandler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                }
+                this.httpClient = new HttpClient(httpHandler);
                 this.httpClient.BaseAddress = new UriBuilder(portName, targetServer, targetPort, targetPath).Uri;
                 this.httpClient.DefaultRequestHeaders.ExpectContinue = false;
                 this.relaySubpath = "/" + relayName;


### PR DESCRIPTION
This PR adds a boolean flag that allows to ignore certificate validation errors for `https` forwarding. It is akin to `--insecure` switch for `curl`. Confilg file has to be used to specify this flag. 

The typical application for this change is a dev environment that uses self-signed certificates.  A more concrete example could  be exposing `minikube` api-server that runs behind NAT (e.g. in the Codespace). Starting from K8s `1.24` they stopped providing plain http access to the api-server and insecure https is the only option.  