### PR TITLE
Reenable win-arm64 CI builds

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -56,9 +56,9 @@ jobs:
     - name: Build for Windows-x64
       run: dotnet msbuild /t:Package /p:WindowsOnly=true /p:RuntimeIdentifier=win-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'windows-latest'
-    #- name: Build for Windows-arm64
-    #  run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-arm /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
-    #  if: matrix.os == 'windows-latest'
+    - name: Build for Windows-arm64
+      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
+      if: matrix.os == 'windows-latest'
     - name: Build for Windows-x86
       run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-x86 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Reenabling Windows Arm64 builds. While build was intended to produce Arm64 binaries it passed `win-arm` RID which represents Arm32 and support for Arm32 was dropped on Windows platform a while ago.

In the rest of the code base we use `win-arm64` so this seems to be a historical typo