### PR TITLE
Run as a service on macOS

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -146,6 +146,18 @@ which is described in [CONFIG.md](CONFIG.md#configuration-file).
 
 The file requires administrative permissions to change.
 
+### MacOS Launchd daemon
+
+On MacOS, the service is registered with Launchd as "com.azure.relay.bridge" and can
+be managed with `launchctl`.
+
+To run either the client or the server side in that daemon, merge the
+configuration file snippets above into the
+`/etc/azbridge/azbridge_config.svc.yml`  file, which is described in
+[CONFIG.md](CONFIG.md#configuration-file).
+
+The file requires administrative permissions to change.
+
 ## Downloads
 
 Unsigned (!) binaries are available for direct download from the [Github

--- a/build/repo.props
+++ b/build/repo.props
@@ -14,6 +14,9 @@
 	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
 		<DefineConstants>_SYSTEMD</DefineConstants>
 	</PropertyGroup>
+	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('osx'))">
+		<DefineConstants>_LAUNCHD</DefineConstants>
+	</PropertyGroup>
 	<ItemGroup>
 		<DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)" />
 	</ItemGroup>

--- a/examples/rdp/README.md
+++ b/examples/rdp/README.md
@@ -175,3 +175,15 @@ configuration file snippets above into the
 [CONFIG.md](CONFIG.md#configuration-file).
 
 The file requires administrative permissions to change.
+
+### MacOS Launchd daemon
+
+On MacOS, the service is registered with Launchd as "com.azure.relay.bridge" and can
+be managed with `launchctl`.
+
+To run either the client or the server side in that daemon, merge the
+configuration file snippets above into the
+`/etc/azbridge/azbridge_config.svc.yml`  file, which is described in
+[CONFIG.md](CONFIG.md#configuration-file).
+
+The file requires administrative permissions to change.

--- a/examples/sqlserver/README.md
+++ b/examples/sqlserver/README.md
@@ -193,3 +193,18 @@ The file requires administrative permissions to change.
 
 As with Windows above, you can also override connection strings at the forwarder
 level on Linux.
+
+### MacOS Launchd daemon
+
+On MacOS, the service is registered with Launchd as "com.azure.relay.bridge" and can
+be managed with `launchctl`.
+
+To run either the client or the server side in that daemon, merge the
+configuration file snippets above into the
+`/etc/azbridge/azbridge_config.svc.yml`  file, which is described in
+[CONFIG.md](CONFIG.md#configuration-file).
+
+The file requires administrative permissions to change.
+
+As with Windows and Linux above, you can also override connection strings at the forwarder
+level on macOS.

--- a/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
+++ b/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtilsPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Relay" Version="$(MicrosoftAzureRelayPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />

--- a/src/azbridge/Program.cs
+++ b/src/azbridge/Program.cs
@@ -54,7 +54,7 @@ namespace azbridge
                     return 0;
                 }
 #endif
-#if _WINDOWS || _SYSTEMD
+#if _WINDOWS || _SYSTEMD || _LAUNCHD
                 if (settings.ServiceRun.HasValue && settings.ServiceRun.Value)
                 {
                     ServiceLauncher.RunAsync(settings).GetAwaiter().GetResult();

--- a/src/azbridge/RelayBridgeService.cs
+++ b/src/azbridge/RelayBridgeService.cs
@@ -1,4 +1,4 @@
-﻿#if _WINDOWS || _SYSTEMD
+﻿#if _WINDOWS || _SYSTEMD || _LAUNCHD
 using Microsoft.Azure.Relay.Bridge.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/azbridge/ServiceLauncher.cs
+++ b/src/azbridge/ServiceLauncher.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if _WINDOWS || _SYSTEMD
+#if _WINDOWS || _SYSTEMD || _LAUNCHD
 namespace azbridge
 {
     using Microsoft.Azure.Relay.Bridge.Configuration;
@@ -9,6 +9,7 @@ namespace azbridge
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Configuration;
+    using Microsoft.Extensions.Logging.Console;
     using Microsoft.Extensions.Logging.EventLog;
     using System;
     using System.Collections;
@@ -95,6 +96,8 @@ namespace azbridge
                 })
 #elif _SYSTEMD
                 .UseSystemd()
+#elif _LAUNCHD
+                .UseLaunchd()
 #endif
 
                 .ConfigureServices(services =>
@@ -182,6 +185,23 @@ namespace azbridge
 #else
              return true;
 #endif
+        }
+
+        private static IHostBuilder UseLaunchd(this IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices(services =>
+            {
+                services.Configure<ConsoleLoggerOptions>(options =>
+                {
+                    options.FormatterName = ConsoleFormatterNames.Simple;
+                });
+                services.Configure<SimpleConsoleFormatterOptions>(options =>
+                {
+                    options.SingleLine = true;
+                });
+            });
+
+            return hostBuilder;
         }
     }
 }

--- a/src/azbridge/azbridge.csproj
+++ b/src/azbridge/azbridge.csproj
@@ -66,6 +66,9 @@
 		<Content Include="azbridge.service" CopyToPublishDirectory="PreserveNewest" Condition="$(DefineConstants.Contains('_SYSTEMD'))">
 			<LinuxPath>/etc/systemd/system/azbridge.service</LinuxPath>
 		</Content>
+		<Content Include="azbridge.plist" CopyToPublishDirectory="PreserveNewest" Condition="$(DefineConstants.Contains('_LAUNCHD'))">
+			<LinuxPath>/Library/LaunchDaemons/com.azure.relay.bridge.plist</LinuxPath>
+		</Content>
 		<Content Include="azbridge.sh" CopyToPublishDirectory="PreserveNewest" Condition="! $(RuntimeIdentifier.StartsWith('win'))" RemoveOnUninstall="true">
 			<LinuxPath>/etc/profile.d/azbridge.sh</LinuxPath>
 			<LinuxFileMode Condition="$(RuntimeIdentifier.StartsWith('linux'))">0555</LinuxFileMode>

--- a/src/azbridge/azbridge.plist
+++ b/src/azbridge/azbridge.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.azure.relay.bridge</string>
+	<key>ProgramArguments</key>
+        <array>
+            <string>/usr/local/share/azbridge/azbridge</string>
+	        <string>--svc</string>
+        </array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<dict>
+		 <key>Crashed</key>
+		 <true/>
+	</dict>
+	<key>StandardOutPath</key>
+	<string>/var/log/azbridge.log</string>
+	<key>StandardErrorPath</key>
+	<string>/var/log/azbridge.log</string>
+</dict>
+</plist>

--- a/test/mysql/mysql.server.dockerfile
+++ b/test/mysql/mysql.server.dockerfile
@@ -1,5 +1,4 @@
-# Pinning to 8.0.35 to get around libssl and libicu dependency errors
-FROM mysql:8.0.35-debian AS build
+FROM mysql:8.0-debian AS build
 ARG package_name
 COPY ./tmp/$package_name .
 RUN apt-get -qq update -y

--- a/test/mysql/mysql.server.dockerfile
+++ b/test/mysql/mysql.server.dockerfile
@@ -1,4 +1,5 @@
-FROM mysql:8.0-debian AS build
+# Pinning to 8.0.35 to get around libssl and libicu dependency errors
+FROM mysql:8.0.35-debian AS build
 ARG package_name
 COPY ./tmp/$package_name .
 RUN apt-get -qq update -y

--- a/test/mysql/test.sh
+++ b/test/mysql/test.sh
@@ -49,6 +49,9 @@ else
             exit 2
         fi
         
+        # mysql does not like world-writable files
+        chmod o-w $(pwd)/my.cnf
+
         # start the web server
         server_name=$(docker run -v $(pwd):/tests -d -v $(pwd)/my.cnf:/etc/mysqld/conf.d/my.cnf --rm -d -e AZBRIDGE_TEST_CXNSTRING="$_CXNSTRING" -e MYSQL_ROOT_PASSWORD=PaSsWoRd112233 -e MYSQL_PASSWORD=PaSsWoRd112233 -e MYSQL_USER=mysql azbridge-mysql-server:latest)
         # wait for server to start

--- a/test/mysql/test.sh
+++ b/test/mysql/test.sh
@@ -48,9 +48,6 @@ else
             echo AZBRIDGE_TEST_CXNSTRING environment variable must be set to valid relay connection string
             exit 2
         fi
-        
-        # mysql does not like world-writable files
-        chmod o-w $(pwd)/my.cnf
 
         # start the web server
         server_name=$(docker run -v $(pwd):/tests -d -v $(pwd)/my.cnf:/etc/mysqld/conf.d/my.cnf --rm -d -e AZBRIDGE_TEST_CXNSTRING="$_CXNSTRING" -e MYSQL_ROOT_PASSWORD=PaSsWoRd112233 -e MYSQL_PASSWORD=PaSsWoRd112233 -e MYSQL_USER=mysql azbridge-mysql-server:latest)


### PR DESCRIPTION
This PR adds support for running `azbridge` as a service on MacOS as a [LaunchDaemon](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/Introduction.html)

This mostly follows the pattern of running `azbridge` as `Systemd` service on Linux with one notable change. Launchd configuration file expects `azbridge` to be located at `/usr/local/share/azbridge/azbridge`. This is because `/usr/share` folder is `read-only` on MacOS.