### PR TITLE
Added Cloud Events media type header support

### DIFF
--- a/src/Microsoft.Azure.Relay.Bridge/CloudEventsMediaTypeHeaderValue.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/CloudEventsMediaTypeHeaderValue.cs
@@ -1,0 +1,36 @@
+﻿using System.Net.Http.Headers;
+
+namespace Microsoft.Azure.Relay.Bridge
+{
+    internal class CloudEventsMediaTypeHeaderValue : MediaTypeHeaderValue
+    {
+        public CloudEventsMediaTypeHeaderValue(string mediaType) : base(mediaType)
+        {
+        }
+
+        public CloudEventsMediaTypeHeaderValue(string mediaType, string charset) : base(mediaType)
+        {
+            Parameters.Add(new NameValueHeaderValue("charset", charset));
+        }
+
+        public static bool TryParse(string input, out CloudEventsMediaTypeHeaderValue parsedValue)
+        {
+            parsedValue = null;
+
+            if (!MediaTypeHeaderValue.TryParse(input, out var mediaType))
+            {
+                return false;
+            }
+
+            if (mediaType.MediaType != "application/cloudevents+json")
+            {
+                return false;
+            }
+
+            var charset = mediaType.CharSet ?? "utf-8";
+            parsedValue = new CloudEventsMediaTypeHeaderValue("application/cloudevents+json", charset);
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
+++ b/src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="$(McMasterExtensionsCommandLineUtilsPackageVersion)" />
     <PackageReference Include="Microsoft.Azure.Relay" Version="$(MicrosoftAzureRelayPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />

--- a/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
@@ -138,7 +138,14 @@ namespace Microsoft.Azure.Relay.Bridge
                 string contentType = context.Request.Headers[HttpRequestHeader.ContentType];
                 if (!string.IsNullOrEmpty(contentType))
                 {
-                    requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                    if (CloudEventsMediaTypeHeaderValue.TryParse(contentType, out var parsedContentType))
+                    {
+                        requestMessage.Content.Headers.ContentType = parsedContentType;
+                    }
+                    else
+                    {
+                        requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                    }
                 }
             }
 


### PR DESCRIPTION
This commit removes the error when forwarding requests with application/cloudevents+json; charset=utf-8 content media format, and the vulnerability issue with the Azure.Identity SDK.