### PR TITLE
Launchd: keep alive azbridge unconditionally

### DIFF
--- a/src/azbridge/azbridge.plist
+++ b/src/azbridge/azbridge.plist
@@ -2,23 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Label</key>
-	<string>com.azure.relay.bridge</string>
-	<key>ProgramArguments</key>
-        <array>
-            <string>/usr/local/share/azbridge/azbridge</string>
-	        <string>--svc</string>
-        </array>
-	<key>RunAtLoad</key>
-	<true/>
-	<key>KeepAlive</key>
-	<dict>
-		 <key>Crashed</key>
-		 <true/>
-	</dict>
-	<key>StandardOutPath</key>
-	<string>/var/log/azbridge.log</string>
-	<key>StandardErrorPath</key>
-	<string>/var/log/azbridge.log</string>
+    <key>Label</key>
+    <string>com.azure.relay.bridge</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/share/azbridge/azbridge</string>
+        <string>--svc</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/azbridge.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/azbridge.log</string>
 </dict>
 </plist>


### PR DESCRIPTION
Changing Launchd KeepAlive property to `true` forcing azbridge to be restarted unconditionally upon exit. 