### PR TITLE
 TcpRemoteForwarder: Parsing the MediaTypeHeaderValue correctly with TryParse and throwing if the parsing fails. 

### DIFF
--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/Config.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/Config.cs
@@ -913,7 +913,9 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
             RemoteForward remoteForward;
             try
             {
-                remoteForward = new RemoteForward { RelayName = rf.Substring(0, firstColon), Http = true };
+                // we're not setting the Http flag here but only at the end of the method
+                // since we don't want a default binding to be created.
+                remoteForward = new RemoteForward { RelayName = rf.Substring(0, firstColon) };
             }
             catch (ArgumentOutOfRangeException e)
             {
@@ -1028,6 +1030,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
                     }
                 }
             }
+            remoteForward.Http = true;
         }
 
         private static void CheckHttpPortName(Config config, string rf, string portName)

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
@@ -148,7 +148,28 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
 
         public bool Http
         {
-            get; set;
+            get
+            {
+                if (bindings.Count == 1)
+                {
+                    return bindings[0].Http;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            set
+            {
+                if (bindings.Count == 0)
+                {
+                    bindings.Add(new RemoteForwardBinding { Http = value });
+                }
+                else
+                {
+                    bindings[0].Http = value;
+                }
+            }
         }
 
 

--- a/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/TcpRemoteForwarder.cs
@@ -138,7 +138,14 @@ namespace Microsoft.Azure.Relay.Bridge
                 string contentType = context.Request.Headers[HttpRequestHeader.ContentType];
                 if (!string.IsNullOrEmpty(contentType))
                 {
-                    requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                    if (MediaTypeHeaderValue.TryParse(contentType, out var mediaTypeHeaderValue))
+                    {
+                        requestMessage.Content.Headers.ContentType = mediaTypeHeaderValue;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Invalid Content-Type header value: {contentType}");
+                    }
                 }
             }
 


### PR DESCRIPTION
Addresses the issue in #91 