### PR TITLE
Addresses issue #8, allowing "." as a separator inside a relay name

### DIFF
--- a/Microsoft.Azure.Relay.Bridge.sln
+++ b/Microsoft.Azure.Relay.Bridge.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 		LICENSE.txt = LICENSE.txt
 		NuGetPackageVerifier.json = NuGetPackageVerifier.json
+		OVERVIEW.md = OVERVIEW.md
 		package-all.cmd = package-all.cmd
 		package.cmd = package.cmd
 		package.sh = package.sh

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/LocalForward.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/LocalForward.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
             {
                 var val = value != null ? value.Trim('\'', '\"') : value;
                 if (val != null && 
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(RelayName),

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/LocalForwardBinding.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/LocalForwardBinding.cs
@@ -160,7 +160,7 @@
             {
                 var val = value != null ? value.Trim('\'', '\"') : value;
                 if (val != null &&
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(PortName),
@@ -180,7 +180,7 @@
                 Uri path;
                 if (val != null &&
                     !Uri.TryCreate(val, UriKind.Absolute, out path) &&
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(BindLocalSocket),

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForward.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
             {
                 var val = value != null ? value.Trim('\'', '\"') : value;
                 if (val != null &&
-                    !new Regex("^[0-9A-Za-z/_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(RelayName),

--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/RemoteForwardBinding.cs
@@ -66,7 +66,7 @@
             {
                 var val = value != null ? value.Trim('\'', '\"') : value;
                 if (val != null &&
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(PortName),
@@ -86,7 +86,7 @@
                 Uri path;
                 if (val != null &&
                     !Uri.TryCreate(val, UriKind.Absolute, out path) &&
-                    !new Regex("^[0-9A-Za-z_-]+$").Match(val).Success)
+                    !Constants.RelayNameRegex.Match(val).Success)
                 {
                     throw BridgeEventSource.Log.ArgumentOutOfRange(
                         nameof(LocalSocket),

--- a/src/Microsoft.Azure.Relay.Bridge/Constants.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Constants.cs
@@ -1,10 +1,12 @@
 ﻿// // Copyright (c) Microsoft. All rights reserved.
 // // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.RegularExpressions;
+
 namespace Microsoft.Azure.Relay.Bridge
 {
-    static class Constants
+    public static class Constants
     {
-        
+        public static Regex RelayNameRegex = new Regex(@"^[0-9A-Za-z/_\-\.]+$", RegexOptions.Compiled);
     }
 }

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
@@ -280,6 +280,56 @@ namespace Microsoft.Azure.Relay.Bridge.Test
         }
 
         [Fact]
+        public void CommandLineGoodRemoteForwardTest()
+        {
+            CommandLineSettings.Run(new string[] { "-R", "foobar:3000" },
+            (settings) =>
+            {
+                var cfg = Config.LoadConfig(settings);
+                Assert.Single(cfg.RemoteForward);
+                Assert.Equal("foobar", cfg.RemoteForward[0].RelayName);
+                Assert.Equal(3000, cfg.RemoteForward[0].HostPort);
+                return 0;
+            });
+            CommandLineSettings.Run(new string[] { "-R", "foobar_foobar:3000" },
+            (settings) =>
+            {
+                var cfg = Config.LoadConfig(settings);
+                Assert.Single(cfg.RemoteForward);
+                Assert.Equal("foobar_foobar", cfg.RemoteForward[0].RelayName);
+                Assert.Equal(3000, cfg.RemoteForward[0].HostPort);
+                return 0;
+            });
+            CommandLineSettings.Run(new string[] { "-R", "foobar/foobar:3000" },
+            (settings) =>
+            {
+                var cfg = Config.LoadConfig(settings);
+                Assert.Single(cfg.RemoteForward);
+                Assert.Equal("foobar/foobar", cfg.RemoteForward[0].RelayName);
+                Assert.Equal(3000, cfg.RemoteForward[0].HostPort);
+                return 0;
+            });
+            CommandLineSettings.Run(new string[] { "-R", "foobar.foobar:3000" },
+            (settings) =>
+            {
+                var cfg = Config.LoadConfig(settings);
+                Assert.Single(cfg.RemoteForward);
+                Assert.Equal("foobar.foobar", cfg.RemoteForward[0].RelayName);
+                Assert.Equal(3000, cfg.RemoteForward[0].HostPort);
+                return 0;
+            });
+            CommandLineSettings.Run(new string[] { "-R", "foobar-foobar:3000" },
+            (settings) =>
+            {
+                var cfg = Config.LoadConfig(settings);
+                Assert.Single(cfg.RemoteForward);
+                Assert.Equal("foobar-foobar", cfg.RemoteForward[0].RelayName);
+                Assert.Equal(3000, cfg.RemoteForward[0].HostPort);
+                return 0;
+            });
+        }
+
+        [Fact]
         public void CommandLineBadRemoteForwardTest()
         {
             var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>


### PR DESCRIPTION
see #8 