### PR TITLE
Remove file system watcher

### DIFF
--- a/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
+++ b/src/Microsoft.Azure.Relay.Bridge/Configuration/CommandLineSettings.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Azure.Relay.Bridge.Configuration
         public string Signature { get; set; }
 
         [Option(CommandOptionType.SingleValue, ShortName = "x", Description = "Azure Relay connection string (overridden with -S -K -k -e)")]
-        public string ConnectionString { get; internal set; }
+        public string ConnectionString { get; set; }
 
         [Option(CommandOptionType.NoValue, ShortName = "v", Description = "Verbose log output")]
-        public bool? Verbose { get; internal set; }
+        public bool? Verbose { get; set; }
 
 
         public static void Run(string[] args, Func<CommandLineSettings, int> callback)

--- a/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
+++ b/test/unit/Microsoft.Azure.Relay.Bridge.Tests/ConfigTest.cs
@@ -4,7 +4,9 @@ namespace Microsoft.Azure.Relay.Bridge.Test
     using System.Configuration;
     using System.Globalization;
     using System.IO;
+    using System.Net.Sockets;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using McMaster.Extensions.CommandLineUtils;
     using Microsoft.Azure.Relay.Bridge.Configuration;
@@ -163,6 +165,9 @@ namespace Microsoft.Azure.Relay.Bridge.Test
 
             Assert.True(callbackInvoked);
         }
+
+
+
 
         [Fact]
         public void CommandLineROptionTest()
@@ -855,5 +860,6 @@ namespace Microsoft.Azure.Relay.Bridge.Test
                 File.Delete(configFileName);
             }
         }
+
     }
 }


### PR DESCRIPTION
This PR fixes #13 by removing the file system watcher and related update mechanisms. Watching the config file and restarting the elements of the bridge affected by a config file change turns out to be very hard to implement reliably and the feature is therefore cut for the time being.