### PR TITLE
Fix Systemd/Launchd config placement

### DIFF
--- a/build/repo.props
+++ b/build/repo.props
@@ -12,12 +12,10 @@
 		<DefineConstants>_WINDOWS</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
-		<DefineConstants>_SYSTEMD</DefineConstants>
-        <DefineConstants>_LINUX</DefineConstants>
+		<DefineConstants>_LINUX;_SYSTEMD</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('osx'))">
-		<DefineConstants>_LAUNCHD</DefineConstants>
-        <DefineConstants>_OSX</DefineConstants>
+		<DefineConstants>_OSX;_LAUNCHD</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)" />


### PR DESCRIPTION
This PR [fixes the placement](https://github.com/Azure/azure-relay-bridge/commit/9e64cc3202cb8753583920c99683eb586c2c1fc8) of Systemd/Launchd config in the final tarball. The issue was in overwriting DefineConstants property that effectively resuited in losing `_SYSTEMD` and `_LAUNCHD` definitions 