### PR TITLE
update Azure.Identity to 1.14.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Azure.Relay" Version="3.0.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2  " />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Azure.Relay" Version="3.0.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.2  " />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />


### PR DESCRIPTION
### Summary
* Bump **Azure.Identity** to **1.14.1** .

update to enable the environment variable `AZURE_TOKEN_CREDENTIALS`.

### Details
| Package | Old | New |
|---------|-----|-----|
| Azure.Identity | 1.12.0 | 1.14.1 |

> No production code changes aside from package versions.  
> `dotnet build -c Release` passes locally on win‑x64

### Checklist
- [x] Builds locally
- [x] success Unit tests at windows locally (Under the condition of xUnit.ParallelizeTestCollections=false)
- [x] Signed Microsoft CLA
